### PR TITLE
Provisioning updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,32 @@ Bytes  | Name              | Contents
 6-15   | Board name        | 10 byte name for the board in ASCII (set unused bytes to 0)
 16-31  | Mfg serial number | 16 byte manufacturer-assigned serial number in ASCII (set unused bytes to 0)
 32-63  | User              | These are unassigned
+
+## Provisioning
+
+The ATECC508A needs to be provisioned before it can be used for the first time.
+This step initializes the ATECC508A configuration, creates a new device certificate,
+and locks the one time programmable memory. Provisioning will require the following
+parameters
+
+  * manufacturer_sn - The serial number of the device
+  * board_name - A string identifier of the version of the hardware board
+  * signer_cert - The CA certificate to sign the device certificate
+  * signer_key - The private key for the signer_cert
+
+Provisioning needs to happen at runtime since the process requires communication
+with the ATECC508A. In the following example, we are reading the signer certificate
+and key from files on the disk. These files were moved onto the device
+prior to running this routine.
+
+```elixir
+signer_cert = File.read!("/root/signer.cert")
+signer_key = File.read!("/root/signer.key")
+
+manufacturer_sn = "1234"
+board_name = "NervesKey"
+
+{:ok, i2c} = ATECC508A.Transport.I2C.init([])
+provision_info = %NervesKey.ProvisioningInfo{manufacturer_sn: manufacturer_sn, board_name: board_name}
+{:ok, _device_cert} = NervesKey.provision(i2c, provision_info, signer_cert, signer_key)
+```

--- a/lib/atecc508a/certificate.ex
+++ b/lib/atecc508a/certificate.ex
@@ -155,7 +155,6 @@ defmodule ATECC508A.Certificate do
       serial_number: X509.Certificate.serial(cert),
       subject_rdn: X509.Certificate.subject(cert),
       issuer_rdn: X509.Certificate.issuer(cert),
-      extensions: X509.Certificate.extensions(cert),
       template: template
     }
   end
@@ -206,7 +205,7 @@ defmodule ATECC508A.Certificate do
             name when is_binary(name) -> RDNSequence.new(name, :otp)
           end,
         subjectPublicKeyInfo: PublicKey.wrap(subject_public_key, :OTPSubjectPublicKeyInfo),
-        extensions: compressed.extensions
+        extensions: template.extensions
       )
 
     otp_certificate(

--- a/lib/atecc508a/certificate/compressed.ex
+++ b/lib/atecc508a/certificate/compressed.ex
@@ -22,7 +22,6 @@ defmodule ATECC508A.Certificate.Compressed do
     :serial_number,
     :subject_rdn,
     :issuer_rdn,
-    :extensions,
     :template
   ]
 
@@ -33,7 +32,6 @@ defmodule ATECC508A.Certificate.Compressed do
           serial_number: binary() | nil,
           subject_rdn: String.t() | X509.RDNSequence.t(),
           issuer_rdn: String.t() | X509.RDNSequence.t(),
-          extensions: [X509.Certificate.Extension.t()],
-          template: ATECC508A.Certificate.Template
+          template: ATECC508A.Certificate.Template.t()
         }
 end

--- a/lib/atecc508a/certificate/template.ex
+++ b/lib/atecc508a/certificate/template.ex
@@ -1,5 +1,15 @@
 defmodule ATECC508A.Certificate.Template do
-  defstruct [:signer_id, :template_id, :chain_id, :sn_source, :device_sn, :certificate_sn]
+  defstruct [
+    :signer_id,
+    :template_id,
+    :chain_id,
+    :sn_source,
+    :device_sn,
+    :certificate_sn,
+    extensions: []
+  ]
+
+  alias X509.Certificate.Extension
 
   @type t :: %__MODULE__{
           signer_id: 0..65535,
@@ -7,28 +17,42 @@ defmodule ATECC508A.Certificate.Template do
           chain_id: 0..15,
           sn_source: ATECC508A.sn_source(),
           device_sn: ATECC508A.serial_number() | nil,
-          certificate_sn: binary() | nil
+          certificate_sn: binary() | nil,
+          extensions: [Extension.t()]
         }
 
-  @spec signer() :: t()
-  def signer() do
+  @spec signer(X509.PublicKey.t()) :: t()
+  def signer(public_key) do
     %__MODULE__{
       signer_id: 0,
       template_id: 1,
       chain_id: 0,
       sn_source: :public_key,
-      device_sn: nil
+      device_sn: nil,
+      extensions: [
+        Extension.basic_constraints(true, 0),
+        Extension.key_usage([:digitalSignature, :keyCertSign, :cRLSign]),
+        Extension.ext_key_usage([:serverAuth, :clientAuth]),
+        Extension.subject_key_identifier(public_key),
+        Extension.authority_key_identifier(public_key)
+      ]
     }
   end
 
-  @spec device(ATECC508A.serial_number()) :: t()
-  def device(device_sn) do
+  @spec device(ATECC508A.serial_number(), X509.PublicKey.t()) :: t()
+  def device(device_sn, signer_public_key) do
     %__MODULE__{
       signer_id: 0,
       template_id: 0,
       chain_id: 0,
       sn_source: :device_sn,
-      device_sn: device_sn
+      device_sn: device_sn,
+      extensions: [
+        Extension.basic_constraints(false),
+        Extension.key_usage([:digitalSignature, :keyEncipherment]),
+        Extension.ext_key_usage([:clientAuth]),
+        Extension.authority_key_identifier(signer_public_key)
+      ]
     }
   end
 end

--- a/lib/nerves_key.ex
+++ b/lib/nerves_key.ex
@@ -45,7 +45,8 @@ defmodule NervesKey do
     :ok = configure(transport)
     otp_info = OTP.new(info.board_name, info.manufacturer_sn)
     otp_data = OTP.to_raw(otp_info)
-    # :ok = OTP.write(transport, otp)
+    :ok = OTP.write(transport, otp_data)
+
     {:ok, device_public_key} = Data.genkey(transport)
     {:ok, device_sn} = Config.device_sn(transport)
 
@@ -64,15 +65,7 @@ defmodule NervesKey do
 
     # No turning back!!
 
-    # :ok = Data.lock(transport, otp_data, slot_data)
-    IO.puts(
-      "Skipping the call to Data.lock(transport, #{inspect(otp_data, limit: :infinity)}, #{
-        inspect(slot_data, limit: :infinity)
-      })"
-    )
-
-    IO.puts("The device certificate is #{inspect(device_cert, limit: :infinity)}")
-    :ok
+    :ok = Data.lock(transport, otp_data, slot_data)
   end
 
   defp check_time() do

--- a/lib/nerves_key/data.ex
+++ b/lib/nerves_key/data.ex
@@ -23,11 +23,17 @@ defmodule NervesKey.Data do
           {ATECC508A.Request.slot(), binary()}
         ]
   def slot_data(device_sn, device_cert, signer_cert) do
-    device_template = ATECC508A.Certificate.Template.device(device_sn)
-    device_compressed = ATECC508A.Certificate.compress(device_cert, device_template)
+    signer_template =
+      signer_cert
+      |> X509.Certificate.public_key()
+      |> ATECC508A.Certificate.Template.signer()
 
-    signer_template = ATECC508A.Certificate.Template.signer()
     signer_compressed = ATECC508A.Certificate.compress(signer_cert, signer_template)
+
+    device_template =
+      ATECC508A.Certificate.Template.device(device_sn, signer_compressed.public_key)
+
+    device_compressed = ATECC508A.Certificate.compress(device_cert, device_template)
 
     # See README.md for slot contents. We still need to program unused slots in order
     # to lock the device so specify nothing so they'll get padded with zeros to the

--- a/lib/nerves_key/otp.ex
+++ b/lib/nerves_key/otp.ex
@@ -53,15 +53,25 @@ defmodule NervesKey.OTP do
         <<@magic::binary(), flags::size(16), board_name::10-bytes, manufacturer_sn::16-bytes,
           user::32-bytes>>
       ) do
-    %__MODULE__{
-      flags: flags,
-      board_name: Util.trim_zeros(board_name),
-      manufacturer_sn: Util.trim_zeros(manufacturer_sn),
-      user: user
-    }
+    {:ok,
+     %__MODULE__{
+       flags: flags,
+       board_name: Util.trim_zeros(board_name),
+       manufacturer_sn: Util.trim_zeros(manufacturer_sn),
+       user: user
+     }}
   end
 
   def from_raw(_other), do: {:error, :not_nerves_key}
+
+  @doc """
+  Convert a raw configuration to a nice map. Raise if there is an error.
+  """
+  @spec from_raw!(<<_::512>>) :: t() | no_return()
+  def from_raw!(raw) do
+    {:ok, raw} = from_raw(raw)
+    raw
+  end
 
   @doc """
   Convert a nice config map back to a raw configuration

--- a/test/atecc508a/certificate_test.exs
+++ b/test/atecc508a/certificate_test.exs
@@ -19,9 +19,13 @@ defmodule ATECC508A.CertificateTest do
 
   test "signer certs can be compressed" do
     {signer_cert, _signer_key} = ATECC508A.Certificate.new_signer(1)
+    signer_public_key = X509.Certificate.public_key(signer_cert)
 
     compressed_cert =
-      ATECC508A.Certificate.compress(signer_cert, ATECC508A.Certificate.Template.signer())
+      ATECC508A.Certificate.compress(
+        signer_cert,
+        ATECC508A.Certificate.Template.signer(signer_public_key)
+      )
 
     decompressed_cert = ATECC508A.Certificate.decompress(compressed_cert)
 
@@ -65,8 +69,13 @@ defmodule ATECC508A.CertificateTest do
         signer_key
       )
 
+    signer_public_key = X509.Certificate.public_key(signer)
+
     compressed =
-      ATECC508A.Certificate.compress(otp_cert, ATECC508A.Certificate.Template.device(ecc508a_sn))
+      ATECC508A.Certificate.compress(
+        otp_cert,
+        ATECC508A.Certificate.Template.device(ecc508a_sn, signer_public_key)
+      )
 
     assert byte_size(compressed.data) == 72
     assert compressed.device_sn == ecc508a_sn
@@ -86,8 +95,13 @@ defmodule ATECC508A.CertificateTest do
         signer_key
       )
 
+    signer_public_key = X509.Certificate.public_key(signer)
+
     compressed =
-      ATECC508A.Certificate.compress(otp_cert, ATECC508A.Certificate.Template.device(ecc508a_sn))
+      ATECC508A.Certificate.compress(
+        otp_cert,
+        ATECC508A.Certificate.Template.device(ecc508a_sn, signer_public_key)
+      )
 
     decompressed = ATECC508A.Certificate.decompress(compressed)
 

--- a/test/nerves_key/otp_test.exs
+++ b/test/nerves_key/otp_test.exs
@@ -13,7 +13,7 @@ defmodule NervesKey.OTPTest do
   }
 
   test "to raw and back" do
-    raw_and_back = @test_data |> OTP.to_raw() |> OTP.from_raw()
+    raw_and_back = @test_data |> OTP.to_raw() |> OTP.from_raw!()
     assert raw_and_back == @test_data
   end
 


### PR DESCRIPTION
This PR does the following

* Fixes issues in `NervesKey.provision` that caused `{:error, :execution_error}` failures.
* Adds a helper function for reading the device certificate.
* Moves extensions from `NervesKey.Certificate.Compressed` to `NervesKey.Certificate.Template`.
* Update README with information on device provisioning.