### PR TITLE
Lock the private key

### DIFF
--- a/lib/nerves_key.ex
+++ b/lib/nerves_key.ex
@@ -116,9 +116,15 @@ defmodule NervesKey do
 
     :ok = Data.write_slots(transport, slot_data)
 
-    # No turning back!!
+    # This is the point of no return!!
 
+    # Lock the data and OTP zones
     :ok = Data.lock(transport, otp_data, slot_data)
+
+    # Lock the slot that contains the private key to prevent calls to GenKey
+    # from changing it. See datasheet for how GenKey doesn't check the zone
+    # lock.
+    :ok = ATECC508A.Request.lock_slot(transport, 0)
   end
 
   defp check_time() do

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "atecc508a": {:hex, :atecc508a, "0.1.0", "3614f3384937c3ceb3c5ea7c78e5d3e6d15727a97a367cd6c09310386deca588", [:mix], [{:circuits_i2c, "~> 0.2", [hex: :circuits_i2c, repo: "hexpm", optional: false]}, {:x509, "~> 0.5", [hex: :x509, repo: "hexpm", optional: false]}], "hexpm"},
+  "atecc508a": {:hex, :atecc508a, "0.1.1", "8ffe1abef9d6c9a75da343de099107ee06d351b0718618b2a93dc4199c282df1", [:mix], [{:circuits_i2c, "~> 0.2", [hex: :circuits_i2c, repo: "hexpm", optional: false]}, {:x509, "~> 0.5", [hex: :x509, repo: "hexpm", optional: false]}], "hexpm"},
   "circuits_i2c": {:hex, :circuits_i2c, "0.3.0", "77920fc456262e95c98d8c6fd953c775a15839fd28e3704ee24ca987b237186c", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.4", "71b42f5ee1b7628f3e3a6565f4617dfb02d127a0499ab3e72750455e986df001", [:mix], [{:erlex, "~> 0.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.0", "17f0c38eaafb4800f746b457313af4b2442a8c2405b49c645768680f900be603", [:mix], [], "hexpm"},
@@ -8,7 +8,7 @@
   "erlex": {:hex, :erlex, "0.1.6", "c01c889363168d3fdd23f4211647d8a34c0f9a21ec726762312e08e083f3d47e", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "i2c": {:git, "https://github.com/elixir-circuits/i2c.git", "34275072c5dd30ac52c89a6d775e74f5bba2fb8f", []},
-  "makeup": {:hex, :makeup, "0.5.5", "9e08dfc45280c5684d771ad58159f718a7b5788596099bdfb0284597d368a882", [:mix], [{:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.5.6", "da47b331b1fe0a5f0380cc3a6967200eac5e1daaa9c6bff4b0310b3fcc12b98f", [:mix], [{:nimble_parsec, "~> 0.4.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "mox": {:hex, :mox, "0.4.0", "7f120840f7d626184a3d65de36189ca6f37d432e5d63acd80045198e4c5f7e6e", [:mix], [], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},


### PR DESCRIPTION
This prevents anyone from ever updating it - accidentally or
maliciously. It turns out that the ATECC508A's genkey command obeys the
slot lock and not the zone lock.