### PR TITLE
Correct matching of config slot

### DIFF
--- a/lib/nerves_key/config.ex
+++ b/lib/nerves_key/config.ex
@@ -74,8 +74,8 @@ defmodule NervesKey.Config do
 
   # See the README.md for an easier-to-view version of what bytes matter
   defp slot_config_compatible(
-         <<0x87, 0x20, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, 0x0F, 0x0F, 0x0F,
-           0x0F, 0x0F, 0x0F, 0x0F, 0x0F, _, _, _, _>>
+         <<0x87, 0x20, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, 0x0F, 0x2F, 0x0F,
+           0x2F, 0x0F, 0x2F, 0x0F, 0x2F, _, _, _, _>>
        ),
        do: true
 


### PR DESCRIPTION
slot_config_compatible() did not match on the correct values of slots 
10, 11,12, and 13.