### PR TITLE
Doc improvements and support for a rewritable device cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ signer_cert = File.read!("/tmp/#{cert_name}.cert") |> X509.Certificate.from_pem!
 signer_key = File.read!("/tmp/#{cert_name}.key") |> X509.PrivateKey.from_pem!();true
 
 {:ok, i2c} = ATECC508A.Transport.I2C.init([])
-NervesKey.provision_aux(i2c, signer_cert, signer_key)
+NervesKey.provision_aux_certificates(i2c, signer_cert, signer_key)
 ```
 
 ## Support

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CircleCI](https://circleci.com/gh/nerves-hub/nerves_key.svg?style=svg)](https://circleci.com/gh/nerves-hub/nerves_key)
 [![Hex version](https://img.shields.io/hexpm/v/nerves_key.svg "Hex version")](https://hex.pm/packages/nerves_key)
 
-The NervesKey is a configured [ATECC508A Crypto
+The NervesKey is a configured [ATECC508A or ATECC608A Crypto
 Authentication](https://www.microchip.com/wwwproducts/en/ATECC508A) chip that's
 used for authenticating devices with NervesHub and other cloud services. At a
 high level, it is simple HSM that protects one private key by requiring all
@@ -19,12 +19,14 @@ device easier. It has the following features:
 4. Support for signing device certificates so that devices can be included in a
    PKI
 5. Support for storing a small amount of run-time configuration in unused data
-   slots
+   EEPROM slots
+6. Support auxillary device/signer certificate storage to support pre-production
+   experimentation without needing to lock down certificates
 
-It cannot be stressed enough that if you are provisioning ATECC508A or ATECC608A
-chips with this library that you keep in mind that the chips are essentially
-one-time programmable. Mistakes are corrected by replacing the chip or the
-entire NervesKey.
+It cannot be stressed enough that the NervesKey library locks down the ATECC508A
+or ATECC608A during the provisioning process. This is a feature and is required
+for normal operation, but if you're getting started, make sure that you have a
+few extra parts just in case.
 
 See the [hw](hw) folder for hardware design files.
 
@@ -45,25 +47,122 @@ Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_do
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at [https://hexdocs.pm/nerves_key](https://hexdocs.pm/nerves_key).
 
+## General use
+
+NervesKeys need to be provisioned before they can be used. That's a one-time
+step that could already have been done for you. If not, see subsequent sections
+for how that works.
+
+To use any of the NervesKey APIs, you will need a "transport" to communicate
+with the ATECC508A or ATECC608A that's doing all of the work. Currently the only
+supported transport is I2C. The following line would be run on your Nerves
+device (like a Raspberry Pi, BeagleBone or your own custom hardware):
+
+```elixir
+iex> {:ok, i2c} = ATECC508A.Transport.I2C.init([])
+```
+
+Check if your NervesKey has been provisioned:
+
+```elixir
+iex> NervesKey.provisioned?(i2c)
+true
+```
+
+If you get `false`, go to the provisioning sections. If you received an error,
+check that the NervesKey has a good connection to your hardware. If you have a
+custom board, you may need to pass parameters to
+`ATECC508A.Transport.I2C.init/1` to set the correct I2C bus.
+
+NervesKeys are provisioned with serial numbers. In production, these can be of
+your choosing.
+
+```elixir
+iex> NervesKey.manufacturer_sn(i2c)
+"ABC12345"
+```
+
+Of course, the more interesting part of the NervesKeys are its storage of device
+private keys and their certificates. For the common case, it stores two X.509
+certificates: one for the device and one for the certificate that signed the device
+certificate. The signer certificate is usually uploaded to the servers that the
+device will connect to so that it can authenticate the device. Here's how
+to get both of the certificates:
+
+```elixir
+iex> NervesKey.device_cert(i2c)
+{:OTPCertificate, ...}
+
+# Put this in a convenient form:
+iex> X509.Certificate.to_pem(v()) |> IO.puts
+-----BEGIN CERTIFICATE-----
+stuff
+stuff
+stuff
+-----END CERTIFICATE-----
+
+iex> NervesKey.signer_cert(i2c)
+{:OTPCertificate, ...}
+```
+
+The next step is to tell Erlang's SSL library that you want to use the NervesKey
+when connecting to the server. For that, you'll need [nerves_key_pkcs11](https://github.com/nerves-hub/nerves_key_pkcs11). This code is somewhat tedious
+but hopefully the following code fragment will help:
+
+```elixir
+   {:ok, engine} = NervesKey.PKCS11.load_engine()
+   {:ok, i2c} = ATECC508A.Transport.I2C.init([])
+
+   signer_cert = X509.Certificate.to_der(NervesKey.signer_cert(i2c))
+   cert = X509.Certificate.to_der(NervesKey.device_cert(i2c))
+   key = NervesKey.PKCS11.private_key(engine, {:i2c, 1})
+   cacerts = [signer_cert] ++ Keyword.get(opts, :trusted_certs, [])
+
+   Tortoise.Supervisor.start_child(
+     server: {
+       Tortoise.Transport.SSL,
+       verify: :verify_peer,
+       host: Keyword.get(opts, :host),
+       cert: cert,
+       key: key,
+       cacerts: cacerts,
+       versions: [:"tlsv1.2"],
+     })
+```
+
 ## Preparing for provisioning
 
-The ATECC508A in the NervesKey needs to be provisioned before it can be used.
-Before you can do that, you'll need a signing certificate and some information
-about your device.
+The ATECC508A/608A in the NervesKey needs to be provisioned before it can be
+used.  Before you can do that, you'll need the following:
+
+1. A signing certificate and its private certificate (in other contexts, this is
+   called a certificate authority)
+2. A serial number for your device
+3. A name for the device
+
+The signing certificate and serial number of very important. After the
+provisioning process, they are locked down and cannot be changed without
+replacing the ATECC508A. The device name is purely informational unless you
+choose to use it otherwise in your software.
+
+NervesKeys support an auxillary set of certificates that identify the device.
+These are writable after the provisioning process. Since they're writable, they
+can be provisioned and updated at any time. As such, they're not programmed in
+the first-time provisioning process.
 
 ### Signing certificates
 
 Part of the provisioning process creates an X.509 certificate for the NervesKey
 that can be used to authenticate TLS connections. This certificate is signed by
-a "signer certificate". This is called a certificate authority in other contexts. You
-will eventually need to upload the signer certificate to NervesHub or AWS IoT or
-wherever you would like to authenticate devices.
+a "signer certificate". You will eventually need to upload the signer
+certificate to NervesHub or AWS IoT or wherever you would like to authenticate
+devices.
 
 Due to memory limitations, the ATECC508A has a way to compress X.509
 certificates on chip. See [ATECC Compressed Certificate
-Definition](https://www.microchip.com/wwwAppNotes/AppNotes.aspx?appnote=en591852). To
-comply with the limitations of compressible certificates, NervesKey provides a
-mix task:
+Definition](https://www.microchip.com/wwwAppNotes/AppNotes.aspx?appnote=en591852).
+To comply with the limitations of compressible certificates, NervesKey provides
+a mix task to create them:
 
 ```sh
 $ mix nerves_key.signer create nerveskey_prod_signer1
@@ -75,8 +174,12 @@ nerveskey_prod_signer1.cert is ready to be uploaded to the servers that need
 to authenticate devices signed by the private key.
 ```
 
+There is no magic in the compressible certificates. They're just limited in what
+they can contain. You can inspect them with `openssl x509 -in
+nerveskey_prod_signer1.cert -text`.
+
 Check with your IoT service on how the signer certificate is used. If it's only
-used for first time device registration, then the signer certificate may not
+used for first-time device registration, then the signer certificate may not
 need a long expiration time. You may also be interested in creating more than
 one signing certificate if you have more than one manufacturing facility.
 
@@ -93,22 +196,22 @@ uniqueness. It is up to the device manufacturer to make sure that the
 their own sanity.
 
 The NervesKey saves the manufacturing serial number in the one-time programmable
-memory on the ATECC508A and also in the devices X.509 certificate. The device's
+memory on the ATECC508A and also in the device's X.509 certificate. The device's
 X.509 certificate is signed, so cloud servers can trust the manufacturer serial
 number.
 
 At this point, you're the manufacturer. Decide how you'd like your serial
-numbers to look. Whatever you pick, it must fit in a 16-bytes when represented
-in ASCII (UTF-8 might work).
+numbers to look. Whatever you pick, it must fit in 16-bytes when represented in
+ASCII (UTF-8 might work, but isn't being tested).
 
 ## Provisioning
 
 Now that you have a signing certificate, the signer's private key, and a
 manufacturer serial number, you can provision a NervesKey or the ATECC508A
-acting as a NervesKey in your device.  Usually there's some custom manufucturing
+acting as a NervesKey in your device.  Usually there's some custom manufacturing
 support software that performs this step. We'll provision at the iex prompt.
 
-Use `sftp` to push the signer certificate and private key to your device. We'll
+Use `sftp` to copy the signer certificate and private key to your device. We'll
 put them `/tmp` so that they disappear on reboot:
 
 ```sh
@@ -128,7 +231,7 @@ Next, go to the IEx prompt on the device and run the following:
 ```elixir
 # Customize these
 cert_name="nerveskey_prod_signer1"
-manufacturer_sn = "NK-1234"
+manufacturer_sn = "N1234"
 board_name = "NervesKey"
 
 # These lines should be copy/paste
@@ -146,8 +249,97 @@ If the last line returns `:ok` after about 2 seconds, then celebrate. You
 successfully programmed a NervesKey. You can't program it again. If you try,
 you'll get an error.
 
+## Provisioning an auxiliary certificate
+
+If a situation arises where the originally provisioned certificate can't be
+used, it's possible to store a second certificate on the device. This second
+certificate uses the same private key as the first certificate. (It is assumed
+that the algorithmic and physical protections on the first private key are
+sufficient that storing two different private keys doesn't add value.) Use cases
+include:
+
+1. Recovering from expiration or loss of the original signer key
+2. Experimentation
+3. Fixing errors in the original certificates
+
+The auxiliary certificate is stored in writable memory on the ATECC508A.
+
+The NervesKey must be provisioned before the auxiliary certificate can be
+written. Assuming that's been done, copy the signer certificate and private key
+to your device similar to what you did before. Then run the following at the IEx
+prompt:
+
+```elixir
+# Customize these
+cert_name="nerveskey_prod_signer1"
+
+# These lines should be copy/paste
+signer_cert = File.read!("/tmp/#{cert_name}.cert") |> X509.Certificate.from_pem!;true
+signer_key = File.read!("/tmp/#{cert_name}.key") |> X509.PrivateKey.from_pem!();true
+
+{:ok, i2c} = ATECC508A.Transport.I2C.init([])
+NervesKey.provision_aux(i2c, signer_cert, signer_key)
+```
+
 ## Support
 
 If you run into problems, please help us improve this project by filing an
 [issue](https://github.com/nerves-hub/nerves_key/issues/new).
 
+## ATECC508A configuration
+
+This section describes the ATECC508A/608A configuration used for the
+[NervesKey](https://github.com/nerves-hub/nerves_key). This information isn't
+needed for using the library.
+
+See Table 2-5 in the ATECC508A data sheet for documentation on the configuration
+zone.  This software expects the following configuration to be programmed
+(unspecified bytes are either not programmable or kept as their defaults):
+
+Bytes  | Name        | Value  | Description
+-------|-------------|--------|------------
+14     | I2C_Enable  | 01     | I2C mode
+16     | I2C_Address | C0     | I2C address of the module (default)
+18     | OTPmode     | AA     | OTP is in read-only mode
+19     | ChipMode    | 00     | Default mode
+20-51  | SlotConfig  | N/A    | See the next table
+92-95  | X509Format  | 00..00 | Unused
+96-127 | KeyConfig   | N/A    | See next table
+
+The slots are programmed as follows. This definition is organized to be similar
+to the Microchip Standard TLS Configuration to minimize changes to other
+software. Unused slots are configured so that applications can use them as they
+would an EEPROM.
+
+Slot | Description                       | SlotConfig | KeyConfig | Primary properties
+-----|-----------------------------------|------------|-----------|-------------------
+0    | Device private key                | 87 20      | 33 00     | Private key, read only; lockable
+1    | Unused                            | 0F 0F      | 1C 00     | Clear read/write; not lockable
+2    | Unused                            | 0F 0F      | 1C 00     | Clear read/write; not lockable
+3    | Unused                            | 0F 0F      | 1C 00     | Clear read/write; not lockable
+4    | Unused                            | 0F 0F      | 1C 00     | Clear read/write; not lockable
+5    | Unused                            | 0F 0F      | 1C 00     | Clear read/write; not lockable
+6    | Unused                            | 0F 0F      | 1C 00     | Clear read/write; not lockable
+7    | Unused                            | 0F 0F      | 1C 00     | Clear read/write; not lockable
+8    | Unused                            | 0F 0F      | 3C 00     | Clear read/write; lockable
+9    | Aux device certificate            | 0F 0F      | 3C 00     | Clear read/write; lockable
+10   | Device certificate                | 0F 2F      | 3C 00     | Clear read only; lockable
+11   | Signer public key                 | 0F 2F      | 30 00     | P256; Clear read only; lockable
+12   | Signer certificate                | 0F 2F      | 3C 00     | Clear read only; lockable
+13   | Signer serial number +            | 0F 2F      | 3C 00     | Clear read only; lockable
+14   | Aux signer public key             | 0F 0F      | 3C 00     | Clear read/write; lockable
+15   | Aux signer certificate            | 0F 0F      | 3C 00     | Clear read/write; lockable
+
++ The signer serial number slot is currently unused since the signer's cert is
+  computed from the public key
+
+The ATECC508A includes a 64 byte OTP (one-time programmable) memory. It has the
+following layout:
+
+Bytes  | Name              | Contents
+-------|-------------------|--------------------------
+0-3    | Magic             | 4e 72 76 73
+4-5    | Flags             | TBD. Set to 0
+6-15   | Board name        | 10 byte name for the board in ASCII (set unused bytes to 0)
+16-31  | Mfg serial number | 16 byte manufacturer-assigned serial number in ASCII (set unused bytes to 0)
+32-63  | User              | These are unassigned

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ operations on that key to occur inside chip. The project provides access to the
 chip from Elixir and makes configuration decisions to make working with the
 device easier. It has the following features:
 
-1. Provision blank ATECC508A devices - this includes private key generation
+1. Provision blank ATECC508A/608A devices - this includes private key generation
 2. Storage for serial number and one-time calibration data (useful if primary
    storage is on a removable MicroSD card)
 3. Support for Microchip's compressed X.509 certificate format for interop with
@@ -23,10 +23,10 @@ device easier. It has the following features:
 6. Support auxillary device/signer certificate storage to support pre-production
    experimentation without needing to lock down certificates
 
-It cannot be stressed enough that the NervesKey library locks down the ATECC508A
-or ATECC608A during the provisioning process. This is a feature and is required
-for normal operation, but if you're getting started, make sure that you have a
-few extra parts just in case.
+It cannot be stressed enough that the NervesKey library locks down the
+ATECC508A/608A during the provisioning process. This is a feature and is
+required for normal operation, but if you're getting started, make sure that you
+have a few extra parts just in case.
 
 See the [hw](hw) folder for hardware design files.
 
@@ -54,7 +54,7 @@ step that could already have been done for you. If not, see subsequent sections
 for how that works.
 
 To use any of the NervesKey APIs, you will need a "transport" to communicate
-with the ATECC508A or ATECC608A that's doing all of the work. Currently the only
+with the ATECC508A/608A that's doing all of the work. Currently the only
 supported transport is I2C. The following line would be run on your Nerves
 device (like a Raspberry Pi, BeagleBone or your own custom hardware):
 
@@ -84,10 +84,10 @@ iex> NervesKey.manufacturer_sn(i2c)
 
 Of course, the more interesting part of the NervesKeys are its storage of device
 private keys and their certificates. For the common case, it stores two X.509
-certificates: one for the device and one for the certificate that signed the device
-certificate. The signer certificate is usually uploaded to the servers that the
-device will connect to so that it can authenticate the device. Here's how
-to get both of the certificates:
+certificates: one for the device and one for the certificate that signed the
+device certificate. The signer certificate is usually uploaded to the servers
+that the device will connect to so that it can authenticate the device. Here's
+how to get both of the certificates:
 
 ```elixir
 iex> NervesKey.device_cert(i2c)
@@ -106,8 +106,9 @@ iex> NervesKey.signer_cert(i2c)
 ```
 
 The next step is to tell Erlang's SSL library that you want to use the NervesKey
-when connecting to the server. For that, you'll need [nerves_key_pkcs11](https://github.com/nerves-hub/nerves_key_pkcs11). This code is somewhat tedious
-but hopefully the following code fragment will help:
+when connecting to the server. For that, you'll need
+[nerves_key_pkcs11](https://github.com/nerves-hub/nerves_key_pkcs11). This code
+is somewhat tedious but hopefully the following code fragment will help:
 
 ```elixir
    {:ok, engine} = NervesKey.PKCS11.load_engine()
@@ -140,10 +141,10 @@ used.  Before you can do that, you'll need the following:
 2. A serial number for your device
 3. A name for the device
 
-The signing certificate and serial number of very important. After the
+The signing certificate and serial number are very important. After the
 provisioning process, they are locked down and cannot be changed without
-replacing the ATECC508A. The device name is purely informational unless you
-choose to use it otherwise in your software.
+replacing the ATECC508A/608A. The device name is purely informational unless you
+choose to use it in your software.
 
 NervesKeys support an auxillary set of certificates that identify the device.
 These are writable after the provisioning process. Since they're writable, they
@@ -158,7 +159,7 @@ a "signer certificate". You will eventually need to upload the signer
 certificate to NervesHub or AWS IoT or wherever you would like to authenticate
 devices.
 
-Due to memory limitations, the ATECC508A has a way to compress X.509
+Due to memory limitations, the ATECC508A/608A has a way to compress X.509
 certificates on chip. See [ATECC Compressed Certificate
 Definition](https://www.microchip.com/wwwAppNotes/AppNotes.aspx?appnote=en591852).
 To comply with the limitations of compressible certificates, NervesKey provides
@@ -189,16 +190,16 @@ Be aware that there are a lot of things called serial numbers. In an attempt to
 minimize confusion, we'll refer to the serial number that identifies the device
 to humans and other machines as the "manufacturer serial number". This string
 (it need not be a number) is commonly printed on a label on a device. It may be
-embedded in a barcode. Other serial numbers exist - the ATECC508A has a 9 byte
-one and X.509 certificates have ones. Those serial numbers have guarantees on
-uniqueness. It is up to the device manufacturer to make sure that the
+embedded in a barcode. Other serial numbers exist - the ATECC508A/608A has a 9
+byte one and X.509 certificates have ones. Those serial numbers have guarantees
+on uniqueness. It is up to the device manufacturer to make sure that the
 "manufacturer serial number" is unique. People generally want to do this for
 their own sanity.
 
 The NervesKey saves the manufacturing serial number in the one-time programmable
-memory on the ATECC508A and also in the device's X.509 certificate. The device's
-X.509 certificate is signed, so cloud servers can trust the manufacturer serial
-number.
+memory on the ATECC508A/608A and also in the device's X.509 certificate. The
+device's X.509 certificate is signed, so cloud servers can trust the
+manufacturer serial number.
 
 At this point, you're the manufacturer. Decide how you'd like your serial
 numbers to look. Whatever you pick, it must fit in 16-bytes when represented in
@@ -207,7 +208,7 @@ ASCII (UTF-8 might work, but isn't being tested).
 ## Provisioning
 
 Now that you have a signing certificate, the signer's private key, and a
-manufacturer serial number, you can provision a NervesKey or the ATECC508A
+manufacturer serial number, you can provision a NervesKey or the ATECC508A/608A
 acting as a NervesKey in your device.  Usually there's some custom manufacturing
 support software that performs this step. We'll provision at the iex prompt.
 
@@ -262,7 +263,7 @@ include:
 2. Experimentation
 3. Fixing errors in the original certificates
 
-The auxiliary certificate is stored in writable memory on the ATECC508A.
+The auxiliary certificate is stored in writable memory on the ATECC508A/608A.
 
 The NervesKey must be provisioned before the auxiliary certificate can be
 written. Assuming that's been done, copy the signer certificate and private key

--- a/hw/README.md
+++ b/hw/README.md
@@ -5,11 +5,11 @@ relatively inexpensive additions to devices that attach to an I2C bus. This
 directory contains circuit board designs to add an ATECC508A/608A to Raspberry
 Pis.
 
-## 5-pin bottom solderable module
+## 5-pin bottom solder-able module
 
 ![NervesKey bottom](proto4/nerves_key_bottom.jpg "NervesKey bottom mount")
 
-The `proto4` directory is a hand solderable module that can be mounted
+The `proto4` directory is a hand solder-able module that can be mounted
 underneath the Raspberry Pi or connected "upside down" to the top.
 
 Parts:

--- a/hw/README.md
+++ b/hw/README.md
@@ -1,13 +1,13 @@
 # Hardware
 
-The Nerves Key is a provisioned ATECC508A or ATECC608A. Both chips are
+The NervesKey is a provisioned ATECC508A or ATECC608A. Both chips are
 relatively inexpensive additions to devices that attach to an I2C bus. This
 directory contains circuit board designs to add an ATECC508A/608A to Raspberry
 Pis.
 
 ## 5-pin bottom solderable module
 
-![NervesKey bottom](proto4/nerves_key_bottom.jpg "Nerves Key bottom mount")
+![NervesKey bottom](proto4/nerves_key_bottom.jpg "NervesKey bottom mount")
 
 The `proto4` directory is a hand solderable module that can be mounted
 underneath the Raspberry Pi or connected "upside down" to the top.
@@ -20,7 +20,7 @@ Parts:
 
 See the [proto4](proto4) directory for Eagle files.
 
-## Nerves Key shim
+## NervesKey shim
 
 ![NervesKey shim](shim/nerves_key_shim1.png) ![NervesKey shim](shim/nerves_key_shim2.png)
 

--- a/lib/nerves_key.ex
+++ b/lib/nerves_key.ex
@@ -1,6 +1,6 @@
 defmodule NervesKey do
   @moduledoc """
-  This is a high level interface to provisioning and using the Nerves Key
+  This is a high level interface to provisioning and using the NervesKey
   or any ATECC508A/608A that can be configured similarly.
   """
 

--- a/lib/nerves_key.ex
+++ b/lib/nerves_key.ex
@@ -100,9 +100,15 @@ defmodule NervesKey do
   end
 
   @doc """
-  Provision a NervesKey in one step
+  Provision a NervesKey in one step.
 
-  This function does it all, but it requires the signer's private key.
+  See the README.md for how to use this. This function locks the
+  ATECC508A down, so you'll want to be sure what you pass it is
+  correct.
+
+  This function does it all. It requires the signer's private key so
+  handle that with care. Alternatively, please consider sending a PR
+  for supporting off-device signatures so that HSMs can be used.
   """
   @spec provision(
           ATECC508A.Transport.t(),

--- a/lib/nerves_key/config.ex
+++ b/lib/nerves_key/config.ex
@@ -1,6 +1,6 @@
 defmodule NervesKey.Config do
   @moduledoc """
-  This is a high level interface to provisioning and using the Nerves Key
+  This is a high level interface to provisioning and using the NervesKey
   or any ATECC508A/608A that can be configured similarly.
   """
 
@@ -16,7 +16,7 @@ defmodule NervesKey.Config do
                  0x0F, 0x2F, 0x0F, 0x0F, 0x0F, 0x0F>>
 
   @doc """
-  Configure an ATECC508A or ATECC608A as a Nerves Key.
+  Configure an ATECC508A or ATECC608A as a NervesKey.
 
   This can only be called once. Subsequent calls will fail.
   """
@@ -58,8 +58,8 @@ defmodule NervesKey.Config do
   end
 
   @doc """
-  Check if the chip's configuration is compatible with the Nerves Key. This only checks
-  what's important for the Nerves Key.
+  Check if the chip's configuration is compatible with the NervesKey. This only checks
+  what's important for the NervesKey.
   """
   @spec config_compatible?(ATECC508A.Transport.t()) :: {:error, atom()} | {:ok, boolean()}
   def config_compatible?(transport) do

--- a/lib/nerves_key/data.ex
+++ b/lib/nerves_key/data.ex
@@ -1,6 +1,6 @@
 defmodule NervesKey.Data do
   @moduledoc """
-  This module handles Data Zone data stored in the Nerves Key.
+  This module handles Data Zone data stored in the NervesKey.
   """
 
   @doc """

--- a/lib/nerves_key/otp.ex
+++ b/lib/nerves_key/otp.ex
@@ -1,6 +1,6 @@
 defmodule NervesKey.OTP do
   @moduledoc """
-  This module handles OTP data stored in the Nerves Key.
+  This module handles OTP data stored in the NervesKey.
   """
 
   alias ATECC508A.{OTPZone, Transport, Util}
@@ -22,7 +22,7 @@ defmodule NervesKey.OTP do
         }
 
   @doc """
-  Create a Nerves Key OTP data struct
+  Create a NervesKey OTP data struct
   """
   @spec new(String.t(), String.t(), binary()) :: t()
   def new(board_name, manufacturer_sn, user \\ <<0::size(256)>>) do
@@ -30,7 +30,7 @@ defmodule NervesKey.OTP do
   end
 
   @doc """
-  Read Nerves Key information from the OTP data.
+  Read NervesKey information from the OTP data.
   """
   @spec read(Transport.t()) :: {:ok, t()} | {:error, atom()}
   def read(transport) do
@@ -40,7 +40,7 @@ defmodule NervesKey.OTP do
   end
 
   @doc """
-  Write Nerves Key information to the OTP zone.
+  Write NervesKey information to the OTP zone.
   """
   @spec write(Transport.t(), binary()) :: :ok | {:error, atom()}
   defdelegate write(transport, data), to: OTPZone


### PR DESCRIPTION
This adds support for a rewritable device and signer cert. The default behavior is still to use the read-only ones set at provisioning time. However, it came up that being able to support an auxiliary device certificate that can be updated after provisioning time would be very useful. 

While I implemented that, I updated the docs quite a bit.