### PR TITLE
Include nerves_key_pkcs11 as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,9 @@ iex> NervesKey.signer_cert(i2c)
 
 The next step is to tell Erlang's SSL library that you want to use the NervesKey
 when connecting to the server. For that, you'll need
-[nerves_key_pkcs11](https://github.com/nerves-hub/nerves_key_pkcs11). This code
-is somewhat tedious but hopefully the following code fragment will help:
+[nerves_key_pkcs11](https://github.com/nerves-hub/nerves_key_pkcs11) which is
+included as a dependency of this library. This code is somewhat tedious but
+hopefully the following code fragment will help:
 
 ```elixir
    {:ok, engine} = NervesKey.PKCS11.load_engine()

--- a/mix.exs
+++ b/mix.exs
@@ -45,6 +45,7 @@ defmodule NervesKey.MixProject do
   defp deps do
     [
       {:atecc508a, "~> 0.2"},
+      {:nerves_key_pkcs11, "~> 0.1"},
       {:ex_doc, "~> 0.20", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0.0-rc.6", only: :dev, runtime: false}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -11,6 +11,7 @@
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "mox": {:hex, :mox, "0.4.0", "7f120840f7d626184a3d65de36189ca6f37d432e5d63acd80045198e4c5f7e6e", [:mix], [], "hexpm"},
+  "nerves_key_pkcs11": {:hex, :nerves_key_pkcs11, "0.2.1", "bccd4faca41081cd1eaa51afc4530ad323fa6fc2085e5ba423306a244aa177e8", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "x509": {:hex, :x509, "0.5.4", "471e84f81464b1a55fd1e5441887c15e6ef251e0ec827647f659fc1f68282bee", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
Pretty much everyone needs to use nerves_key_pkcs11 so include it as a
dependency to avoid the error where you forget to add it or misspell it.