### PR TITLE
Add ssl_opts helper to simplify integrations

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,7 @@ defmodule NervesKey.MixProject do
 
   defp deps do
     [
-      {:atecc508a, "~> 0.2"},
+      {:atecc508a, "~> 0.2.1"},
       {:nerves_key_pkcs11, "~> 0.1"},
       {:ex_doc, "~> 0.20", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0.0-rc.6", only: :dev, runtime: false}


### PR DESCRIPTION
This saves boilerplate code when using a NervesKey with libraries that
use TLS like NervesHub, Tortoise, etc.