### PR TITLE
Update the Installation section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ NervesKey and NervesHub documentation.
 
 See [hw/hw.md](hw/hw.md) for hardware information or go to
 [Tindie/NervesKey](https://www.tindie.com/products/troodonsw/nerveskey/) for a
-prebuilt-one. 
+prebuilt-one.
 There are a few options for purchase as breakout boards with STEMMA QT / Qwiic 4-Pin JST SH connectors
 - Adafruit ATECC608 - https://www.adafruit.com/product/4314
 - Sparkfun ATECC508A - https://www.sparkfun.com/products/15573
@@ -41,8 +41,7 @@ There are a few options for purchase as breakout boards with STEMMA QT / Qwiic 4
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `nerves_key` to your list of dependencies in `mix.exs`:
+The package can be installed by adding `nerves_key` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
@@ -52,9 +51,7 @@ def deps do
 end
 ```
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/nerves_key](https://hexdocs.pm/nerves_key).
+The docs can be found at [https://hexdocs.pm/nerves_key](https://hexdocs.pm/nerves_key).
 
 ## General use
 


### PR DESCRIPTION
This PR is a minor improvement in README.md.  Currently the content of the Installation section is outdated. It looks like the default generated by mix. It would be nice to be updated.

## Notes

As I scanned through some other Nerves Hub projects, I found that that there are a few patterns:

- The Installation section is outdated like this project
- The installation section is briefly edited so it makes sense
- The entire Installation section is omitted

My commit takes the pattern from https://github.com/nerves-hub/nerves_hub_user_api, but we could choose to remove the entire installation section.
