### PR TITLE
Re: Trust and Go support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 nerves_key-*.tar
 
+.elixir_ls/

--- a/lib/nerves_key.ex
+++ b/lib/nerves_key.ex
@@ -374,7 +374,12 @@ defmodule NervesKey do
   def provision_aux_certificates(transport, signer_cert, signer_key, type \\ :nerves_key) do
     check_time()
 
-    manufacturer_sn = manufacturer_sn(transport, type)
+    manufacturer_sn = if type == :nerves_key do
+      manufacturer_sn(transport)
+    else
+      manufacturer_mac(transport, :trust_and_go)
+    end
+
     {:ok, device_public_key} = Data.genkey(transport, false)
     {:ok, device_sn} = Config.device_sn(transport)
 

--- a/lib/nerves_key.ex
+++ b/lib/nerves_key.ex
@@ -374,11 +374,12 @@ defmodule NervesKey do
   def provision_aux_certificates(transport, signer_cert, signer_key, type \\ :nerves_key) do
     check_time()
 
-    manufacturer_sn = if type == :nerves_key do
-      manufacturer_sn(transport)
-    else
-      manufacturer_mac(transport, :trust_and_go)
-    end
+    manufacturer_sn =
+      if type == :nerves_key do
+        manufacturer_sn(transport)
+      else
+        manufacturer_mac(transport, :trust_and_go)
+      end
 
     {:ok, device_public_key} = Data.genkey(transport, false)
     {:ok, device_sn} = Config.device_sn(transport)

--- a/lib/nerves_key.ex
+++ b/lib/nerves_key.ex
@@ -63,6 +63,16 @@ defmodule NervesKey do
   end
 
   def manufacturer_sn(transport, :trust_and_go) do
+    {:ok, config} = ATECC508A.Configuration.read(transport)
+    %ATECC508A.Configuration{serial_number: sn_bytes} = config
+    Base.encode16(sn_bytes)
+  end
+
+  @doc """
+  IEEE EUI-48 MAC address that can be used as a unique identifier in LAN networking
+  This is only available on `:trust_and_go`
+  """
+  def manufacturer_mac(transport, :trust_and_go) do
     {:ok, <<eui48::bytes-12, _::binary>>} = ATECC508A.DataZone.read(transport, 5)
     eui48
   end

--- a/lib/nerves_key.ex
+++ b/lib/nerves_key.ex
@@ -63,7 +63,7 @@ defmodule NervesKey do
   end
 
   def manufacturer_sn(transport, :trust_and_go) do
-    {:ok, <<eui48::bytes-11, _::binary>>} = ATECC508A.DataZone.read(transport, 5)
+    {:ok, <<eui48::bytes-12, _::binary>>} = ATECC508A.DataZone.read(transport, 5)
     eui48
   end
 
@@ -170,7 +170,7 @@ defmodule NervesKey do
     ski = :crypto.hash(:sha, <<4>> <> public_key_raw)
     signer_id_hex_str = Integer.to_string(signer_id, 16)
 
-    {:ok, <<eui48::bytes-11, _::binary>>} = ATECC508A.DataZone.read(transport, 5)
+    eui48 = manufacturer_sn(transport, :trust_and_go)
 
     template =
       ATECC508A.Certificate.TrustAndGoTemplate.device(

--- a/lib/nerves_key.ex
+++ b/lib/nerves_key.ex
@@ -182,7 +182,7 @@ defmodule NervesKey do
     ski = :crypto.hash(:sha, <<4>> <> public_key_raw)
     signer_id_hex_str = Integer.to_string(signer_id, 16)
 
-    eui48 = manufacturer_sn(transport, :trust_and_go)
+    eui48 = manufacturer_mac(transport, :trust_and_go)
 
     template =
       ATECC508A.Certificate.TrustAndGoTemplate.device(

--- a/lib/nerves_key.ex
+++ b/lib/nerves_key.ex
@@ -82,21 +82,23 @@ defmodule NervesKey do
 
   Pass an engine and optionally which certificate that you'd like to use.
   """
-  @spec ssl_opts(ATECC508A.Transport.t(), certificate_pair()) :: keyword()
-  def ssl_opts(transport, which \\ :primary) do
+  @spec ssl_opts(ATECC508A.Transport.t(), certificate_pair(), device_type()) :: keyword()
+  def ssl_opts(transport, which \\ :primary, type \\ :nerves_key) do
     {:ok, engine} = NervesKey.PKCS11.load_engine()
 
     cert =
-      NervesKey.device_cert(transport, which)
+      NervesKey.device_cert(transport, which, type)
       |> X509.Certificate.to_der()
 
     signer_cert =
-      NervesKey.signer_cert(transport, which)
+      NervesKey.signer_cert(transport, which, type)
       |> X509.Certificate.to_der()
 
     transport_info = ATECC508A.Transport.info(transport)
 
-    key = NervesKey.PKCS11.private_key(engine, i2c: i2c_instance(transport_info.bus_name))
+    key =
+      NervesKey.PKCS11.private_key(engine, i2c: i2c_instance(transport_info.bus_name), type: type)
+
     cacerts = [signer_cert]
 
     [key: key, cert: cert, cacerts: cacerts]

--- a/lib/nerves_key/data.ex
+++ b/lib/nerves_key/data.ex
@@ -35,12 +35,12 @@ defmodule NervesKey.Data do
     signer_template =
       signer_cert
       |> X509.Certificate.public_key()
-      |> ATECC508A.Certificate.Template.signer()
+      |> ATECC508A.Certificate.NervesKeyTemplate.signer()
 
     signer_compressed = ATECC508A.Certificate.compress(signer_cert, signer_template)
 
     device_template =
-      ATECC508A.Certificate.Template.device(device_sn, signer_compressed.public_key)
+      ATECC508A.Certificate.NervesKeyTemplate.device(device_sn, signer_compressed.public_key)
 
     device_compressed = ATECC508A.Certificate.compress(device_cert, device_template)
 
@@ -90,12 +90,12 @@ defmodule NervesKey.Data do
     signer_template =
       signer_cert
       |> X509.Certificate.public_key()
-      |> ATECC508A.Certificate.Template.signer()
+      |> ATECC508A.Certificate.NervesKeyTemplate.signer()
 
     signer_compressed = ATECC508A.Certificate.compress(signer_cert, signer_template)
 
     device_template =
-      ATECC508A.Certificate.Template.device(device_sn, signer_compressed.public_key)
+      ATECC508A.Certificate.NervesKeyTemplate.device(device_sn, signer_compressed.public_key)
 
     device_compressed = ATECC508A.Certificate.compress(device_cert, device_template)
 

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,8 @@ defmodule NervesKey.MixProject do
     [
       # {:atecc508a, "~> 1.0 or ~> 0.3.0"},
       {:atecc508a, github: "nerves-hub/atecc508a", branch: "trust-and-go"},
-      {:nerves_key_pkcs11, "~> 1.0 or ~> 0.2"},
+      # {:nerves_key_pkcs11, "~> 1.0 or ~> 0.2"},
+      {:nerves_key_pkcs11, github: "nerves-hub/nerves_key_pkcs11", branch: "trust-and-go"},
       {:ex_doc, "~> 0.20", only: :docs, runtime: false},
       {:dialyxir, "~> 1.1", only: :dev, runtime: false}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -52,10 +52,8 @@ defmodule NervesKey.MixProject do
 
   defp deps do
     [
-      # {:atecc508a, "~> 1.0 or ~> 0.3.0"},
-      {:atecc508a, github: "nerves-hub/atecc508a", branch: "trust-and-go"},
-      # {:nerves_key_pkcs11, "~> 1.0 or ~> 0.2"},
-      {:nerves_key_pkcs11, github: "nerves-hub/nerves_key_pkcs11", branch: "trust-and-go"},
+      {:atecc508a, "~> 1.1 or ~> 0.3.0"},
+      {:nerves_key_pkcs11, "~> 1.0 or ~> 0.2"},
       {:ex_doc, "~> 0.20", only: :docs, runtime: false},
       {:dialyxir, "~> 1.1", only: :dev, runtime: false}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,8 @@ defmodule NervesKey.MixProject do
 
   defp deps do
     [
-      {:atecc508a, "~> 1.0 or ~> 0.3.0"},
+      # {:atecc508a, "~> 1.0 or ~> 0.3.0"},
+      {:atecc508a, github: "nerves-hub/atecc508a", branch: "trust-and-go"},
       {:nerves_key_pkcs11, "~> 1.0 or ~> 0.2"},
       {:ex_doc, "~> 0.20", only: :docs, runtime: false},
       {:dialyxir, "~> 1.1", only: :dev, runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "atecc508a": {:git, "https://github.com/nerves-hub/atecc508a.git", "cd9e1a00bef9df5bc2c56cba4d39099d6241a990", [branch: "trust-and-go"]},
+  "atecc508a": {:git, "https://github.com/nerves-hub/atecc508a.git", "2611b7483239b699bd144e71153da08e8dc849b2", [branch: "trust-and-go"]},
   "circuits_i2c": {:hex, :circuits_i2c, "1.0.1", "3a820dfa04bc5a92d0ec3c572cacb1a665802b2913fbc25784ed5a2020f12626", [:make, :mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "e11393b3f462154ebec5d100859bd5d616e958d9f701e4d62af5764ee84f5213"},
   "dialyxir": {:hex, :dialyxir, "1.1.0", "c5aab0d6e71e5522e77beff7ba9e08f8e02bad90dfbeffae60eaf0cb47e29488", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "07ea8e49c45f15264ebe6d5b93799d4dd56a44036cf42d0ad9c960bc266c0b9a"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.16", "607709303e1d4e3e02f1444df0c821529af1c03b8578dfc81bb9cf64553d02b9", [:mix], [], "hexpm", "69fcf696168f5a274dd012e3e305027010658b2d1630cef68421d6baaeaccead"},
@@ -9,7 +9,7 @@
   "makeup": {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c", [:mix], [{:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.15.2", "dc72dfe17eb240552857465cc00cce390960d9a0c055c4ccd38b70629227e97c", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "fd23ae48d09b32eff49d4ced2b43c9f086d402ee4fd4fcb2d7fad97fa8823e75"},
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
-  "nerves_key_pkcs11": {:hex, :nerves_key_pkcs11, "1.0.0", "4c93907613182969ff7594c6dafe1eb6608a45dac35eb8ee8df18ab4f323dbac", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "b7fdb0194e78d0f163e39bd33d3b301f8280d09a182ec42a85abf30e774b8a08"},
+  "nerves_key_pkcs11": {:git, "https://github.com/nerves-hub/nerves_key_pkcs11.git", "fa7f5adb460747804c7af91a8de628fbdf273755", [branch: "trust-and-go"]},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
   "x509": {:hex, :x509, "0.8.3", "2306b7e9e9dce35cf16a2608c8d85027fa35f37b33c500b775362bbfd388d224", [:mix], [], "hexpm", "101650f2f35de8528878ae9cd449cb2d0cdcd9974733640ef320fad757594684"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "atecc508a": {:git, "https://github.com/nerves-hub/atecc508a.git", "2611b7483239b699bd144e71153da08e8dc849b2", [branch: "trust-and-go"]},
+  "atecc508a": {:hex, :atecc508a, "1.1.0", "8bcbc5e46e04cd48d5cf2c219559e65b4333fd85cbb86bc659f8993312014a69", [:mix], [{:circuits_i2c, "~> 1.0 or ~> 0.2", [hex: :circuits_i2c, repo: "hexpm", optional: false]}, {:x509, "~> 0.5.1 or ~> 0.6", [hex: :x509, repo: "hexpm", optional: false]}], "hexpm", "ebfdacc6b40e8051ac550e7df45b8d5f1f78fdc39d771d2d8209e16ad02196ac"},
   "circuits_i2c": {:hex, :circuits_i2c, "1.0.1", "3a820dfa04bc5a92d0ec3c572cacb1a665802b2913fbc25784ed5a2020f12626", [:make, :mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "e11393b3f462154ebec5d100859bd5d616e958d9f701e4d62af5764ee84f5213"},
   "dialyxir": {:hex, :dialyxir, "1.1.0", "c5aab0d6e71e5522e77beff7ba9e08f8e02bad90dfbeffae60eaf0cb47e29488", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "07ea8e49c45f15264ebe6d5b93799d4dd56a44036cf42d0ad9c960bc266c0b9a"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.16", "607709303e1d4e3e02f1444df0c821529af1c03b8578dfc81bb9cf64553d02b9", [:mix], [], "hexpm", "69fcf696168f5a274dd012e3e305027010658b2d1630cef68421d6baaeaccead"},
@@ -9,7 +9,7 @@
   "makeup": {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c", [:mix], [{:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.15.2", "dc72dfe17eb240552857465cc00cce390960d9a0c055c4ccd38b70629227e97c", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "fd23ae48d09b32eff49d4ced2b43c9f086d402ee4fd4fcb2d7fad97fa8823e75"},
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
-  "nerves_key_pkcs11": {:git, "https://github.com/nerves-hub/nerves_key_pkcs11.git", "fa7f5adb460747804c7af91a8de628fbdf273755", [branch: "trust-and-go"]},
+  "nerves_key_pkcs11": {:hex, :nerves_key_pkcs11, "1.1.0", "b24edcbf079b311fe18bb411a7d3cc32a5dea4a70de20c8f3bde8b96a0db0044", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "c11b955aaf4da2d3225e9f7edc2203d8cc3a7da37763829a869a9296ee9583fb"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
   "x509": {:hex, :x509, "0.8.3", "2306b7e9e9dce35cf16a2608c8d85027fa35f37b33c500b775362bbfd388d224", [:mix], [], "hexpm", "101650f2f35de8528878ae9cd449cb2d0cdcd9974733640ef320fad757594684"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
-  "atecc508a": {:hex, :atecc508a, "1.0.0", "7a3fb92b1abe893987773ca4b89d3bac1cc1b7b3fa3e5b6563e7450d9dc88161", [:mix], [{:circuits_i2c, "~> 1.0 or ~> 0.2", [hex: :circuits_i2c, repo: "hexpm", optional: false]}, {:x509, "~> 0.5.1 or ~> 0.6", [hex: :x509, repo: "hexpm", optional: false]}], "hexpm", "d1d247e93ec16ef2bdc6fa606bfd24f928d9cfc7b21458b5543f98473e2e283c"},
-  "circuits_i2c": {:hex, :circuits_i2c, "1.0.0", "0b9c686ff5075f9364209fef62f6b5162eeb41a0061571f52f02637b40ca37fe", [:make, :mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "f80efc49235e7819b9ea8e82c7dbd5e2523c65d8e3d4f46f89dfd43217a3f4f7"},
+  "atecc508a": {:git, "https://github.com/nerves-hub/atecc508a.git", "cd9e1a00bef9df5bc2c56cba4d39099d6241a990", [branch: "trust-and-go"]},
+  "circuits_i2c": {:hex, :circuits_i2c, "1.0.1", "3a820dfa04bc5a92d0ec3c572cacb1a665802b2913fbc25784ed5a2020f12626", [:make, :mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "e11393b3f462154ebec5d100859bd5d616e958d9f701e4d62af5764ee84f5213"},
   "dialyxir": {:hex, :dialyxir, "1.1.0", "c5aab0d6e71e5522e77beff7ba9e08f8e02bad90dfbeffae60eaf0cb47e29488", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "07ea8e49c45f15264ebe6d5b93799d4dd56a44036cf42d0ad9c960bc266c0b9a"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.16", "607709303e1d4e3e02f1444df0c821529af1c03b8578dfc81bb9cf64553d02b9", [:mix], [], "hexpm", "69fcf696168f5a274dd012e3e305027010658b2d1630cef68421d6baaeaccead"},
   "elixir_make": {:hex, :elixir_make, "0.6.3", "bc07d53221216838d79e03a8019d0839786703129599e9619f4ab74c8c096eac", [:mix], [], "hexpm", "f5cbd651c5678bcaabdbb7857658ee106b12509cd976c2c2fca99688e1daf716"},


### PR DESCRIPTION
Again, picking up the great work from @ConnorRigby --
* locking in the new dep versions
* revising the name of a device's MAC address vs Serial Number
* Add `device_type` argument to settings functions so we use the right slots for each chip type