### PR TITLE
v1.1.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.1.0 - 2022-03-02
+
+* New features
+  * Add support for Trust and Go (ATECC608B-TNGTLS) pre-provisioned chips, many functions can now 
+    accept a `device_type()` argument to switch which type of chip it will communicate with. 
+
 ## v1.0.0 - 2021-10-23
 
 This release only bumps the version number. It doesn't have any code changes.

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule NervesKey.MixProject do
   use Mix.Project
 
-  @version "1.0.0"
+  @version "1.1.0"
   @source_url "https://github.com/nerves-hub/nerves_key"
 
   def project do


### PR DESCRIPTION
## v1.1.0 - 2022-03-02

* New features
  * Add support for Trust and Go (ATECC608B-TNGTLS) pre-provisioned chips, many functions can now 
    accept a `device_type()` argument to switch which type of chip it will communicate with. 