### PR TITLE
Add volatile key configuration as an option.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,13 @@ version: 2.1
 latest: &latest
   pattern: "^1.18.*-erlang-27.*$"
 
-tags: &tags
-  [
+tags:
+  &tags [
     1.18.3-erlang-27.3-alpine-3.21.3,
     1.17.3-erlang-27.2-alpine-3.20.3,
     1.16.2-erlang-26.2.4-alpine-3.19.1,
     1.15.7-erlang-26.1.2-alpine-3.18.4,
     1.14.2-erlang-25.2-alpine-3.17.0,
-    1.13.4-erlang-24.3.4-alpine-3.15.3
   ]
 
 jobs:

--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -2,5 +2,6 @@
 [
   {"lib/x509/certificate.ex:20:23:unknown_type Unknown type: X509.ASN1.record/1."},
   {"lib/x509/private_key.ex:33:57:unknown_type Unknown type: :public_key.ec_private_key/0."},
-  {"lib/x509/public_key.ex:9:56:unknown_type Unknown type: :public_key.ec_public_key/0."}
+  {"lib/x509/public_key.ex:9:56:unknown_type Unknown type: :public_key.ec_public_key/0."},
+  {"lib/x509/public_key.ex:11:56:unknown_type Unknown type: :public_key.ec_public_key/0."}
 ]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ decisions to make working with the device easier. It has the following features:
    EEPROM slots
 6. Support auxillary device/signer certificate storage to support pre-production
    experimentation without needing to lock down certificates
+7. (bonus) Optionally lock down the hardware device with an activation key. More
+   complex but offers a method of storing encryption keys. See Volatile key
+   configuration later in this document.
 
 It cannot be stressed enough that the NervesKey library locks down the
 ATECC508A/608A during the provisioning process. This is a feature and is
@@ -450,3 +453,77 @@ Bytes  | Name              | Contents
 6-15   | Board name        | 10 byte name for the board in ASCII (set unused bytes to 0)
 16-31  | Mfg serial number | Serial number in ASCII (set unused bytes to 0)
 32-63  | Serial# or User   | If Flags == 1, then the rest of the serial number
+
+## ATECC608 volatile key configuration
+
+Volatile key configuration is an option for the ATECC608 chips (A & B). You can reference
+[a datasheet here](https://ww1.microchip.com/downloads/en/DeviceDoc/ATECC608A-TFLXTLS-CryptoAuthentication-Data-Sheet-DS40002138A.pdf)
+but it does not describe all the features. If you find anywhere that Microchip publishes
+the datasheet including the Volatile Key functionality we'd love to reference it properly.
+
+This is an alternate but largely compatible configuration of the NervesKey intended to
+add additional security features. It uses two major features of the ATECC608 that the
+508 does not fully support. The Volatile Key config and the Persistent Latch.
+
+The configuration sets up an "activation key" (AES, so any 16 bytes should do) in key slot 1
+as the key to unlock operation of the chip. It also sets up an "encryption key" (also AES)
+in slot 2. These keys are generated outside the chip but also locked into the chip during
+provisioning. The NervesKey Device Private Key (slot 0) and Encryption Key (slot 2) will be
+disabled until the host demonstrates that it has access to the Activation Key. It requires
+authorization. Once authorization is given the chip is fully enabled and can be used as a
+regular NervesKey for mTLS and such. The Encryption Key can also be used to derive other keys
+such as disk encryption or database encryption keys.
+
+It will maintain this authorization using the Persistent Latch. A bit that is persisted as long
+as the device has power. If power is lost authorization goes away and the NervesKey can not be
+used when power is restored unless the authorization is provided again. This allows hooking it
+up to tamper protection in various ways.
+
+The ATECC608 has *severe limitations* in protecting symmetric encryption keys. The AES feature
+passes decrypted information in cleartext over I2C. This configuration is an option for cases
+where you want that higher level of security and are willing to trade off on convenience.
+
+**Important:** If you cannot secure the physical aspect with some kind of tamper mechanism,
+this config adds complexity but really only provides obscurity. With proper tamper protection,
+this should provide reasonable protection for secrets like disk encryption keys. If your board
+has other secure storage via ARM TrustZone or similar you don't need this mechanism. With the
+appropriate physical and electronic protections in place this can add key storage to a
+Raspberry Pi which lacks protected storage.
+
+Providing authorization is up to the application but could be done with a PIN-code, password,
+USB key or something else.
+
+Bytes  | Name                  | Value  | Description
+-----  | --------------------- | ------ | -----------
+14     | I2C_Enable            | 01     | I2C mode
+16     | I2C_Address           | C0     | I2C address of the module (default)
+18     | OTPmode               | AA     | OTP is in read-only mode
+19     | ChipMode              | 00     | Default mode
+20-51  | SlotConfig            | N/A    | See the next table
+69     | VolatileKeyPermission | 81     | VolKeyPermitSlot=1, VolKeyPermitEnable=true
+92-95  | X509Format            | 00..00 | Unused
+96-127 | KeyConfig             | N/A    | See next table
+
+The slots are programmed as follows. This definition is organized to be similar
+to the Microchip Standard TLS Configuration to minimize changes to other
+software. It only differs from the base NervesKey in disabling the private key until authorized
+and including an AES key for use with deriving secrets.
+
+Slot | Description              | SlotConfig | KeyConfig | Primary properties
+---- | ------------------------ | ---------- | --------- | ------------------
+0    | Device private key       | 87 20      | 33 10     | Private key, read only; lockable; persistent disable
+1    | Activation key           | 81 90      | 78 00     | AES key, require RNG
+2    | Encryption key           | 81 90      | 38 10     | AES key, persistent disable
+3    | Unused                   | 0F 0F      | 1C 00     | Clear read/write; not lockable
+4    | Unused                   | 0F 0F      | 1C 00     | Clear read/write; not lockable
+5    | Settings (Part 3)        | 0F 0F      | 1C 00     | Clear read/write; not lockable
+6    | Settings (Part 2)        | 0F 0F      | 1C 00     | Clear read/write; not lockable
+7    | Settings (Part 1)        | 0F 0F      | 1C 00     | Clear read/write; not lockable
+8    | Settings (Part 0)        | 0F 0F      | 3C 00     | Clear read/write; lockable
+9    | Aux device certificate   | 0F 0F      | 3C 00     | Clear read/write; lockable
+10   | Device certificate       | 0F 2F      | 3C 00     | Clear read only; lockable
+11   | Signer public key        | 0F 2F      | 30 00     | P256; Clear read only; lockable
+12   | Signer certificate       | 0F 2F      | 3C 00     | Clear read only; lockable
+13   | Signer serial number +   | 0F 2F      | 3C 00     | Clear read only; lockable
+14   | Aux signer public key    | 0F 0F      | 3C 00     | Clear read/write; lockable
+15   | Aux signer certificate   | 0F 0F      | 3C 00     | Clear read/write; lockable

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -35,9 +35,10 @@ SPDX-License-Identifier = "SHL-0.51"
 [[annotations]]
 path = [
  "hw/assets/assembled.jpg",
- "hw/assets/bottom_mount.jpg"
+ "hw/assets/bottom_mount.jpg",
+ "docs/provision-volatile-key-config.livemd",
+ "docs/volatile-config-test.livemd"
 ]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "None"
 SPDX-License-Identifier = "CC0-1.0"
-

--- a/docs/provision-volatile-key-config.livemd
+++ b/docs/provision-volatile-key-config.livemd
@@ -1,0 +1,120 @@
+# Provision Volatile Key Configuration
+
+```elixir
+Mix.install([:nerves_key, :atecc508a])
+```
+
+## Setup
+
+```elixir
+{:ok, i2c} = ATECC508A.Transport.I2C.init([])
+```
+
+## Set up your keys
+
+**Warning!**
+
+Remember that provisioning an ATECC608 chip is permanent. If it goes wrong or you use the wrong key it cannot be fixed, changed or restored.
+
+Particularly for the volatile configuration, losing the `activation key` will mean you cannot use the chip for much of anything.
+
+```elixir
+manufacturer_sn_field = Kino.Input.text("Your serial number", default: "LAB00001")
+board_name_field = Kino.Input.text("Board name", default: "PowerBoard5000")
+cert_name_field = Kino.Input.text("Certificate name", default: "nerveskey-test-signer1")
+
+activation_field = Kino.Input.text("Activation key", default: "correcthorsenail")
+encryption_field = Kino.Input.text("Encryption key", default: "nailhorsecorrect")
+accepted_field = Kino.Input.checkbox("I understand the consequences")
+fields = [manufacturer_sn_field, board_name_field, cert_name_field, activation_field, encryption_field, accepted_field]
+Kino.Layout.grid(fields, columns: 3) |> Kino.render()
+
+# These keys are considered test keys and we share the private key intentionally
+cert_field = Kino.Input.textarea("Signer certificate", default: """
+-----BEGIN CERTIFICATE-----
+MIIBpzCCAU2gAwIBAgIQc3p50MJrn1hkMJ20b6c6cjAKBggqhkjOPQQDAjARMQ8w
+DQYDVQQDDAZTaWduZXIwHhcNMjQwNDE5MTEwMDAwWhcNMjUwNDE5MTEwMDAwWjAR
+MQ8wDQYDVQQDDAZTaWduZXIwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARyJw8a
+eyEXB4jxcsTCgyh8vCa5IV7IaOkGIWunkoTmFh16UkAdAJG3dpQRhiooBxl5+ADe
+vcMFkPeIPScLGZx3o4GGMIGDMBIGA1UdEwEB/wQIMAYBAf8CAQAwDgYDVR0PAQH/
+BAQDAgGGMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAdBgNVHQ4EFgQU
+32moIyTaiQOONSkBK3EUTXXn9kEwHwYDVR0jBBgwFoAU32moIyTaiQOONSkBK3EU
+TXXn9kEwCgYIKoZIzj0EAwIDSAAwRQIgCQ/QP5EJrabRoPs9F6iJR3bEzl20gqGB
+dCVsdeA9dKUCIQDftgLAbaQujGuq3riTcb0T8VsA1ayweAh9PsRZveVSiQ==
+-----END CERTIFICATE-----
+""")
+
+key_field = Kino.Input.textarea("Signer key", default: """
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEID9UV6zO4sVnA+yeCL7SF36dcU841YPmXZfRQ6htENkyoAoGCCqGSM49
+AwEHoUQDQgAEcicPGnshFweI8XLEwoMofLwmuSFeyGjpBiFrp5KE5hYdelJAHQCR
+t3aUEYYqKAcZefgA3r3DBZD3iD0nCxmcdw==
+-----END EC PRIVATE KEY-----
+""")
+
+pk_fields = [cert_field, key_field]
+
+Kino.Layout.grid(pk_fields, columns: 2)
+
+```
+
+```elixir
+activation_key = Kino.Input.read(activation_field)
+encryption_key = Kino.Input.read(encryption_field)
+accepted? = Kino.Input.read(accepted_field)
+
+activation_key_size = byte_size(activation_key)
+# Condition will produce an error for 0 length or >16 byte
+activation_key =
+  cond do
+    activation_key_size == 16 -> activation_key
+    activation_key_size < 16 and activation_key_size > 0 ->
+      pad = 16 - activation_key_size
+      IO.puts("Short key, padding #{pad} bytes")
+      <<activation_key::binary, 0::size(pad * 8)>>
+  end
+
+encryption_key_size = byte_size(encryption_key)
+# Condition will produce an error for 0 length or >16 byte
+encryption_key =
+  cond do
+    encryption_key_size == 16 -> encryption_key
+    encryption_key_size < 16 and encryption_key_size > 0 ->
+      pad = 16 - encryption_key_size
+      IO.puts("Short key, padding #{pad} bytes")
+      <<encryption_key::binary, 0::size(pad * 8)>>
+  end
+
+# Validate some things
+signer_cert =
+  cert_field
+  |> Kino.Input.read()
+  |> X509.Certificate.from_pem!()
+
+signer_key =
+  key_field
+  |> Kino.Input.read()
+  |> X509.PrivateKey.from_pem!()
+
+manufacturer_sn = Kino.Input.read(manufacturer_sn_field)
+board_name = Kino.Input.read(board_name_field)
+```
+
+```elixir
+provision_info =
+  %NervesKey.ProvisioningInfo{
+    manufacturer_sn: manufacturer_sn,
+    board_name: board_name
+  }
+IO.inspect(activation_key)
+if accepted? do
+  IO.inspect(NervesKey.provisioned?(i2c), label: "provisioned")
+  if not NervesKey.provisioned?(i2c) do
+    NervesKey.volatile_provision(i2c, provision_info, signer_cert, signer_key, activation_key, encryption_key)
+  else
+    IO.puts("Already provisioned.")
+  end
+else
+  IO.puts("You have not confirmed that you understand the consequences :)")
+end
+```

--- a/docs/volatile-config-test.livemd
+++ b/docs/volatile-config-test.livemd
@@ -1,0 +1,64 @@
+# Test volatile key config
+
+```elixir
+Mix.install([:nerves_key, :atecc508a])
+```
+
+## Confirm locked down
+
+```elixir
+{:ok, i2c} = ATECC508A.Transport.I2C.init([])
+```
+
+```elixir
+
+# If this is not cleared it has already been unlocked, fully remove power from the ATECC608 to
+# run the tests properly
+{:ok, <<0::32>>} = ATECC508A.Request.get_latch(i2c)
+```
+
+## Signing a digest fails, the private key is locked
+
+```elixir
+digest = ATECC508A.Host.digest("foo")
+# 0x0F is Execution Error and the appropriate failure mode
+{:ok, <<0x0F>>} = NervesKey.sign_digest(i2c, digest)
+```
+
+## Generating a MAC should fail
+
+```elixir
+<<input::32-bytes>> = <<0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef::size(32*8)>>
+# Key 2 is the encryption key and that is locked down
+{:ok, <<0x0F>>} = ATECC508A.Request.mac_deterministic(i2c, 2, input)
+```
+
+## Activate keys
+
+```elixir
+activation_key = "correcthorsenail"
+
+<<_::32-bytes>> = padded_key = <<activation_key::binary, 0::size(16*8)>>
+ATECC508A.Request.auth_volatile_key(i2c, 1, padded_key)
+```
+
+## Signing a digest should work
+
+```elixir
+digest = ATECC508A.Host.digest("foo")
+# 0x0F is Execution Error and the appropriate failure mode
+{:ok, <<_::64-bytes>>} = NervesKey.sign_digest(i2c, digest)
+```
+
+## Generate a MAC should succeed
+
+```elixir
+<<input::32-bytes>> = <<0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef::size(32*8)>>
+# Key 2 is the encryption key and that is locked down
+{:ok, <<mac1::32-bytes>>} = ATECC508A.Request.mac_deterministic(i2c, 2, input)
+{:ok, <<mac2::32-bytes>>} = ATECC508A.Request.mac_deterministic(i2c, 2, input)
+{:ok, <<mac3::32-bytes>>} = ATECC508A.Request.mac_deterministic(i2c, 2, :crypto.strong_rand_bytes(32))
+{:ok, <<mac4::32-bytes>>} = ATECC508A.Request.mac_deterministic(i2c, 2, :crypto.strong_rand_bytes(32))
+IO.inspect(mac3 != mac4, label: "Different input, different output")
+mac1 == mac2
+```

--- a/lib/nerves_key.ex
+++ b/lib/nerves_key.ex
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2021 Alex McLain
 # SPDX-FileCopyrightText: 2022 Connor Rigby
 # SPDX-FileCopyrightText: 2022 Digit
+# SPDX-FileCopyrightText: 2025 Lars Wikman
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -371,6 +372,76 @@ defmodule NervesKey do
   end
 
   @doc """
+  Provision a NervesKey for the volatile key config in one step.
+
+  See the README.md for how to use this. This function locks the
+  ATECC508A down, so you'll want to be sure what you pass it is
+  correct. Ensure you have the activation key in safe storage, it
+  will be required to use the NervesKey.
+
+  This function does it all. It requires the signer's private key so
+  handle that with care. Alternatively, please consider sending a PR
+  for supporting off-device signatures so that HSMs can be used.
+  """
+  @spec volatile_provision(
+          ATECC508A.Transport.t(),
+          ProvisioningInfo.t(),
+          X509.Certificate.t(),
+          X509.PrivateKey.t(),
+          binary(),
+          binary()
+        ) :: :ok
+  def volatile_provision(
+        transport,
+        info,
+        signer_cert,
+        signer_key,
+        <<_::128>> = activation_key,
+        <<_::128>> = encryption_key
+      ) do
+    check_time()
+
+    {:ok, config} = ATECC508A.Configuration.read(transport)
+    # Ensure the device supports volatile key config
+    true = ATECC508A.Configuration.supports_volatile?(config)
+
+    :ok = volatile_configure(transport)
+    otp_info = OTP.new(info.board_name, info.manufacturer_sn)
+    otp_data = OTP.to_raw(otp_info)
+    :ok = OTP.write(transport, otp_data)
+
+    {:ok, device_public_key} = Data.genkey(transport)
+    {:ok, device_sn} = Config.device_sn(transport)
+
+    device_cert =
+      ATECC508A.Certificate.new_device(
+        device_public_key,
+        device_sn,
+        info.manufacturer_sn,
+        signer_cert,
+        signer_key
+      )
+
+    slot_data =
+      Data.volatile_slot_data(device_sn, device_cert, signer_cert, activation_key, encryption_key)
+
+    :ok = Data.write_slots(transport, slot_data)
+
+    # This is the point of no return!!
+
+    # Lock the data and OTP zones
+    :ok = Data.lock(transport, otp_data, slot_data)
+
+    # Lock the slot that contains the private key to prevent calls to GenKey
+    # from changing it. See datasheet for how GenKey doesn't check the zone
+    # lock.
+    # Lock the slots containing the activation and encryption keys.
+    :ok = ATECC508A.Request.lock_slot(transport, 0)
+    :ok = ATECC508A.Request.lock_slot(transport, 1)
+    :ok = ATECC508A.Request.lock_slot(transport, 2)
+  end
+
+  @doc """
   Provision the auxiliary device/signer certificates on a NervesKey.
 
   This function creates and saves the auxiliary certificates. These
@@ -571,6 +642,14 @@ defmodule NervesKey do
       Config.config_compatible?(transport) == {:ok, true} -> :ok
       Config.configured?(transport) == {:ok, true} -> {:error, :config_locked}
       true -> Config.configure(transport)
+    end
+  end
+
+  defp volatile_configure(transport) do
+    cond do
+      Config.volatile_config_compatible?(transport) == {:ok, true} -> :ok
+      Config.configured?(transport) == {:ok, true} -> {:error, :config_locked}
+      true -> Config.configure_volatile(transport)
     end
   end
 

--- a/lib/nerves_key/config.ex
+++ b/lib/nerves_key/config.ex
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2018 Frank Hunleth
 # SPDX-FileCopyrightText: 2019 Justin Schneck
 # SPDX-FileCopyrightText: 2019 Peter C. Marks
+# SPDX-FileCopyrightText: 2025 Lars Wikman
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -21,13 +22,353 @@ defmodule NervesKey.Config do
                  0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x2F, 0x0F, 0x2F, 0x0F, 0x2F,
                  0x0F, 0x2F, 0x0F, 0x0F, 0x0F, 0x0F>>
 
+  # The structure of key configs and slot configs which let's us print the current config on
+  # a device. Mostly useful during development of new configs. But an absolute pain to not
+  # have.
+  # Also provides the necessary offsets and lengths to be able to edit specific fields without
+  # touching the rest of the config.
+  @key [
+    [
+      private: 1,
+      pub_info: 1,
+      key_type: 3,
+      lockable: 1,
+      req_random: 1,
+      req_auth: 1
+    ],
+    [auth_key: 4, persistent_disable: 1, unused: 1, x509_id: 2]
+  ]
+
+  @slot [
+    [
+      read_key: 4,
+      no_mac: 1,
+      limited_use: 1,
+      encrypt_read: 1,
+      is_secret: 1
+    ],
+    [write_key: 4, write_config: 4]
+  ]
+
+  def set_volatile_key(
+        %Configuration.Config608{
+          key_config: key_config,
+          slot_config: slot_config
+        } = info,
+        key_id
+      ) do
+    volatile = %{enabled?: true, key: key_id}
+
+    key_config =
+      key_config
+      # Don't disable they key we rely on, would be bad
+      |> set_key_config(key_id, :persistent_disable, 0)
+      # Set ReqRandom on the volatile key
+      |> set_key_config(key_id, :req_random, 1)
+      # Set ReqAuth to not require auth on the volatile key
+      |> set_key_config(key_id, :req_auth, 0)
+      |> set_key_config(key_id, :auth_key, 0)
+      # Set KeyType to be AES
+      |> set_key_config(key_id, :key_type, 6)
+      # Allow locking the slot
+      |> set_key_config(key_id, :lockable, 1)
+
+    slot_config =
+      slot_config
+      # Disable CheckMac Copy operation
+      |> set_slot_config(key_id, :read_key, 1)
+      # Should be usable with the MAC command
+      |> set_slot_config(key_id, :no_mac, 0)
+      # Ensure no use limit
+      |> set_slot_config(key_id, :limited_use, 0)
+      # Not requiring encrypted read because reads will not be allowed
+      |> set_slot_config(key_id, :encrypt_read, 0)
+      # Is secret
+      |> set_slot_config(key_id, :is_secret, 1)
+      # Disable WriteKey
+      |> set_slot_config(key_id, :write_key, 0)
+      # Never allow changing the key
+      |> set_slot_config(key_id, :write_config, 0b1001)
+
+    %{info | key_config: key_config, slot_config: slot_config, volatile_key_permission: volatile}
+  end
+
+  def set_encryption_key(
+        %Configuration.Config608{
+          key_config: key_config,
+          slot_config: slot_config
+        } = info,
+        key_id
+      ) do
+    key_config =
+      key_config
+      # Disable if persistent latch not set
+      |> set_key_config(key_id, :persistent_disable, 1)
+      # Don't require random
+      |> set_key_config(key_id, :req_random, 0)
+      # Don't require auth
+      |> set_key_config(key_id, :req_auth, 0)
+      |> set_key_config(key_id, :auth_key, 0)
+      # Set KeyType to be AES
+      |> set_key_config(key_id, :key_type, 6)
+      # Allow locking the slot
+      |> set_key_config(key_id, :lockable, 1)
+
+    slot_config =
+      slot_config
+      # Disable CheckMac Copy operation
+      |> set_slot_config(key_id, :read_key, 1)
+      # Should be usable with the MAC command
+      |> set_slot_config(key_id, :no_mac, 0)
+      # Ensure no use limit
+      |> set_slot_config(key_id, :limited_use, 0)
+      # Not requiring encrypted read because reads will not be allowed
+      |> set_slot_config(key_id, :encrypt_read, 0)
+      # Is secret
+      |> set_slot_config(key_id, :is_secret, 1)
+      # Disable WriteKey
+      |> set_slot_config(key_id, :write_key, 0)
+      # Never allow changing the key
+      |> set_slot_config(key_id, :write_config, 0b1001)
+
+    %{info | key_config: key_config, slot_config: slot_config}
+  end
+
+  def set_persistent_disable(
+        %ATECC508A.Configuration.Config608{
+          key_config: key_config
+        } = info,
+        key_id
+      ) do
+    key_config =
+      key_config
+      |> set_key_config(key_id, :persistent_disable, 1)
+
+    %{info | key_config: key_config}
+  end
+
+  def config do
+    {@key_config, @slot_config}
+  end
+
+  @doc """
+  Prints configuration of device slots.
+  """
+  def print_slots(transport, slots) do
+    {:ok, %{slot_config: slot_config, key_config: key_config}} = Configuration.read(transport)
+
+    key_config =
+      key_config
+      |> twobyte()
+
+    slot_config =
+      slot_config
+      |> twobyte()
+
+    Enum.zip(key_config, slot_config)
+    |> Enum.with_index()
+    |> Enum.each(fn {{key, slot}, index} ->
+      if is_nil(slots) || index in slots do
+        IO.puts("\n\n--- Slot #{index} -----------------------------")
+
+        IO.puts(
+          "slot: #{inspect(slot, as: :binary, base: :hex)} :: #{inspect(slot, as: :binary, base: :binary)}"
+        )
+
+        IO.puts(
+          "key: #{inspect(key, as: :binary, base: :hex)} :: #{inspect(key, as: :binary, base: :binary)}"
+        )
+
+        IO.puts("\n")
+
+        unpack_slot(slot)
+        unpack_key(key)
+      end
+    end)
+  end
+
+  defp twobyte(binary) do
+    case binary do
+      <<part::binary-size(2)>> ->
+        [part]
+
+      <<part::binary-size(2), rest::binary>> ->
+        [part, twobyte(rest)]
+    end
+    |> List.flatten()
+  end
+
+  defp unpack_key(key) do
+    IO.puts("\nKey config:")
+    # key config, 16 bit (2 byte), 16 slots, 32 bytes from 96 to 127
+    <<
+      # Private - Contains an ECC private key otherwise may contain something else
+      private::size(1),
+      # PubInfo - Can this public key be generated?
+      pub_info::size(1),
+      # KeyType - 0-3 unused, 4 - ECC Key, 5 - unused, 6 - AES key, 7 - SHA or other data
+      key_type::size(3),
+      # Lockable - Can be individually locked by Lock command
+      lockable::size(1),
+      # ReqRandom - Require a random Nonce for various commands
+      req_random::size(1),
+      # ReqAuth - Require authentication using AuthKey to make this key usable
+      req_auth::size(1),
+      # AuthKey - KeyID of key used to authenticate this key
+      auth_key::size(4),
+      # PersistentDisable - Key is only usable if persistent latch is set.
+      persistent_disable::size(1),
+      # Unused
+      _unused::size(1),
+      # X509id - id of x509format array in configuration zone corresponding to this slot
+      x509_id::size(2)
+    >> = key
+
+    bindings = binding()
+
+    max_k = bindings |> Enum.map(&String.length(to_string(elem(&1, 0)))) |> Enum.max()
+    max_v = bindings |> Enum.map(&String.length(to_string(elem(&1, 1)))) |> Enum.max()
+
+    key
+    |> format(@key)
+    |> Enum.map(fn {k, v, s, o} ->
+      binary =
+        v
+        |> b2()
+        |> String.pad_leading(s, ["0"])
+        |> String.pad_leading(16 - o)
+
+      "#{String.pad_trailing(to_string(k), max_k, ["."])}..#{String.pad_leading(to_string(v), max_v, ["."])} :: #{binary}"
+    end)
+    |> Enum.join("\n")
+    |> IO.puts()
+  end
+
+  defp get_key_bit_offset(sizes, key) do
+    sizes
+    |> Enum.reduce_while(0, fn {k, size}, offset ->
+      if key == k do
+        {:halt, {offset, size}}
+      else
+        {:cont, offset + size}
+      end
+    end)
+  end
+
+  defp get_key_offsets(format, key) do
+    format
+    |> Enum.with_index()
+    |> Enum.reduce_while(0, fn {keys, index}, _ ->
+      if Keyword.has_key?(keys, key) do
+        {:halt, {index, get_key_bit_offset(keys, key)}}
+      else
+        {:cont, 0}
+      end
+    end)
+  end
+
+  def set_key_config(key_config, slot_id, key, value) do
+    set_key_in_config(key_config, @key, slot_id, key, value)
+  end
+
+  def set_slot_config(slot_config, slot_id, key, value) do
+    set_key_in_config(slot_config, @slot, slot_id, key, value)
+  end
+
+  defp set_key_in_config(key_config, format, slot_id, key, value) do
+    slot_offset = slot_id * 16
+    slot_rem = 16 * 16 - (slot_offset + 16)
+    <<pre_slot::size(slot_offset), slot::2-bytes, post_slot::size(slot_rem)>> = key_config
+
+    {byte_offset, {bit_offset, bit_size}} = get_key_offsets(format, key)
+    byte_rem = 1 - byte_offset
+
+    <<pre_byte::binary-size(byte_offset), byte::binary-size(1), post_byte::binary-size(byte_rem)>> =
+      slot
+
+    bit_rem = 8 - (bit_offset + bit_size)
+    <<post_bits::size(bit_rem), _old_value::size(bit_size), pre_bits::size(bit_offset)>> = byte
+
+    <<pre_slot::size(slot_offset), pre_byte::binary-size(byte_offset), post_bits::size(bit_rem),
+      value::size(bit_size), pre_bits::size(bit_offset), post_byte::binary-size(byte_rem),
+      post_slot::size(slot_rem)>>
+  end
+
+  defp format(binary, [format1, format2]) do
+    <<byte1::binary-size(1), byte2::binary-size(1)>> = binary
+
+    [format(byte1, format1, 0, 0), format(byte2, format2, 0, 8)]
+    |> List.flatten()
+  end
+
+  defp format(binary, format, offset, base_offset) do
+    case format do
+      [] ->
+        []
+
+      [{name, bits} | format] ->
+        rem = 8 - (offset + bits)
+        <<_skip::size(rem), part::size(bits), _::size(offset)>> = binary
+
+        [
+          {name, part, bits, offset + base_offset},
+          format(binary, format, offset + bits, base_offset)
+        ]
+    end
+  end
+
+  defp unpack_slot(slot) do
+    IO.puts("\nSlot config:")
+    # slot config, 16 bit (2 byte), 16 slots, 32 bytes from 20 to 51
+    <<
+      # read_key, 4 bits
+      # different meaning if private key
+      # for non-private: KeyID for key to use to encrypt data being Read from this slot
+      read_key::size(4),
+      # NoMac - Disallow using slot for MAC command
+      no_mac::size(1),
+      # LimitedUse - Limited usages based on counter0
+      limited_use::size(1),
+      # EncryptRead
+      encrypt_read::size(1),
+      # IsSecret - Should it contain keys? Should it be protected? If so: 1
+      is_secret::size(1),
+      # WriteKey - KeyID for which key is used to validate writes to this slot
+      write_key::size(4),
+      # WriteConfig - Control details of how
+      write_config::size(4)
+    >> = slot
+
+    bindings = binding()
+
+    max_k = bindings |> Enum.map(&String.length(to_string(elem(&1, 0)))) |> Enum.max()
+    max_v = bindings |> Enum.map(&String.length(to_string(elem(&1, 1)))) |> Enum.max()
+
+    slot
+    |> format(@slot)
+    |> Enum.map(fn {k, v, s, o} ->
+      binary =
+        v
+        |> b2()
+        |> String.pad_leading(s, ["0"])
+        |> String.pad_leading(16 - o)
+
+      "#{String.pad_trailing(to_string(k), max_k, ["."])}..#{String.pad_leading(to_string(v), max_v, ["."])} :: #{binary}"
+
+      # "#{String.pad_trailing(to_string(k), max_k, ["."])}..#{String.pad_leading(to_string(v), max_v, ["."])} :: #{inspect(v, base: :binary)}"
+      # "#{String.pad_trailing(to_string(k), max_k, ["."])}..#{String.pad_leading(to_string(v), max_v, ["."])} :: #{bin(v)}"
+    end)
+    |> Enum.join("\n")
+    |> IO.puts()
+  end
+
   @doc """
   Configure an ATECC508A or ATECC608A as a NervesKey.
 
   This can only be called once. Subsequent calls will fail.
   """
   @spec configure(ATECC508A.Transport.t()) :: {:error, atom()} | :ok
-  def configure(transport) do
+  def configure(transport, lock? \\ true) do
     with {:ok, info} <- Configuration.read(transport),
          provision_info = %Configuration{
            info
@@ -38,7 +379,46 @@ defmodule NervesKey.Config do
              x509_format: <<0, 0, 0, 0>>
          },
          :ok <- Configuration.write(transport, provision_info) do
-      Configuration.lock(transport, provision_info)
+      if lock? do
+        Configuration.lock(transport, provision_info)
+      else
+        :ok
+      end
+    end
+  end
+
+  @doc """
+  Configure an ATECC508A or ATECC608A as a NervesKey with a volatile setup.
+
+  This can only be called once. Subsequent calls will fail.
+  """
+  @spec configure_volatile(ATECC508A.Transport.t()) :: {:error, atom()} | :ok
+  def configure_volatile(transport, lock? \\ true) do
+    with {:ok, info} <- Configuration.read(transport, :atecc608),
+         provision_info =
+           %Configuration.Config608{
+             info
+             | key_config: @key_config,
+               slot_config: @slot_config,
+               count_match: 0xAA,
+               chip_mode: 0,
+               x509_format: <<0, 0, 0, 0>>
+           }
+           # Require activation key to set auth the volatile key config
+           # and enable setting the persistent latch
+           |> set_volatile_key(1)
+           # configure encryption key slot
+           |> set_encryption_key(2)
+           # Disable device private key unless latch set
+           |> set_persistent_disable(0)
+           # Disable encryption key unless latch set
+           |> set_persistent_disable(2),
+         :ok <- Configuration.write(transport, provision_info) do
+      if lock? do
+        Configuration.lock(transport, provision_info)
+      else
+        :ok
+      end
     end
   end
 
@@ -89,6 +469,19 @@ defmodule NervesKey.Config do
     end
   end
 
+  def volatile_config_compatible?(transport) do
+    with {:ok, %Configuration.Config608{} = info} <- Configuration.read(transport, :atecc608) do
+      answer =
+        info.lock_config == 0 and
+          info.chip_mode == 0 and
+          slot_config_volatile(info.slot_config) and
+          key_config_volatile(info.key_config) and
+          info.volatile_key_permission.enabled?
+
+      {:ok, answer}
+    end
+  end
+
   # See the README.md for an easier-to-view version of what bytes matter
   defp slot_config_compatible(
          <<0x87, 0x20, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, 0x0F, 0x2F, 0x0F,
@@ -98,6 +491,16 @@ defmodule NervesKey.Config do
 
   defp slot_config_compatible(_), do: false
 
+  defp slot_config_volatile(
+         <<0x87, 0x20, 0x91, 0x90, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, 0x0F, 0x2F,
+           0x0F, 0x2F, 0x0F, 0x2F, 0x0F, 0x2F, _, _, _, _>>
+       ),
+       do: true
+
+  defp slot_config_volatile(_) do
+    false
+  end
+
   defp key_config_compatible(
          <<0x33, 0x00, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, 0x3C, 0x00, 0x30,
            0x00, 0x3C, 0x00, 0x3C, 0x00, _, _, _, _>>
@@ -105,4 +508,16 @@ defmodule NervesKey.Config do
        do: true
 
   defp key_config_compatible(_), do: false
+
+  defp key_config_volatile(
+         <<0x33, 0x10, 0x78, 0x0, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, 0x3C, 0x00,
+           0x30, 0x00, 0x3C, 0x00, 0x3C, 0x00, _, _, _, _>>
+       ),
+       do: true
+
+  defp key_config_volatile(_), do: false
+
+  defp b2(val) do
+    :io_lib.format("~.02B", [val]) |> to_string()
+  end
 end

--- a/lib/nerves_key/data.ex
+++ b/lib/nerves_key/data.ex
@@ -74,6 +74,61 @@ defmodule NervesKey.Data do
   end
 
   @doc """
+  Determine what's in all of the data slots
+  """
+  @spec volatile_slot_data(
+          ATECC508A.serial_number(),
+          X509.Certificate.t(),
+          X509.Certificate.t(),
+          binary(),
+          binary()
+        ) ::
+          [
+            {ATECC508A.Request.slot(), binary()}
+          ]
+  def volatile_slot_data(
+        device_sn,
+        device_cert,
+        signer_cert,
+        <<_::128>> = activation_key,
+        <<_::128>> = encryption_key
+      ) do
+    signer_template =
+      signer_cert
+      |> X509.Certificate.public_key()
+      |> ATECC508A.Certificate.NervesKeyTemplate.signer()
+
+    signer_compressed = ATECC508A.Certificate.compress(signer_cert, signer_template)
+
+    device_template =
+      ATECC508A.Certificate.NervesKeyTemplate.device(device_sn, signer_compressed.public_key)
+
+    device_compressed = ATECC508A.Certificate.compress(device_cert, device_template)
+
+    # See README.md for slot contents. We still need to program unused slots in order
+    # to lock the device so specify nothing so they'll get padded with zeros to the
+    # appropriate size.
+    [
+      {1, activation_key},
+      {2, encryption_key},
+      {3, <<>>},
+      {4, <<>>},
+      {5, <<>>},
+      {6, <<>>},
+      {7, <<>>},
+      {8, <<>>},
+      {9, <<>>},
+      {10, device_compressed.data},
+      {11, signer_compressed.public_key},
+      {12, signer_compressed.data},
+      {13, <<>>},
+      {14, <<>>},
+      {15, <<>>}
+    ]
+    |> Enum.map(fn {slot, data} -> {slot, ATECC508A.DataZone.pad_to_slot_size(slot, data)} end)
+  end
+
+  @doc """
   Write all of the slots
   """
   @spec write_slots(ATECC508A.Transport.t(), [{ATECC508A.Request.slot(), binary()}]) :: :ok

--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,7 @@ defmodule NervesKey.MixProject do
       description: description(),
       package: package(),
       source_url: @source_url,
-      elixir: "~> 1.13",
+      elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       docs: docs(),
@@ -64,7 +64,7 @@ defmodule NervesKey.MixProject do
 
   defp deps do
     [
-      {:atecc508a, "~> 1.1 or ~> 0.3.0"},
+      {:atecc508a, "~> 1.4"},
       {:nerves_key_pkcs11, "~> 1.0 or ~> 0.2"},
       {:ex_doc, "~> 0.20", only: :docs, runtime: false},
       {:dialyxir, "~> 1.1", only: :dev, runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "atecc508a": {:hex, :atecc508a, "1.3.0", "52c15f59a2ffba9615f9404bbb3251b120f427690ea6a8e1f1cd2d9fe8265354", [:mix], [{:circuits_i2c, "~> 0.2 or ~> 1.0 or ~> 2.0", [hex: :circuits_i2c, repo: "hexpm", optional: false]}, {:x509, "~> 0.5.1 or ~> 0.6", [hex: :x509, repo: "hexpm", optional: false]}], "hexpm", "ce4345ed949e962682b0d479cddf3bb94169d06f015544cd6450d76cbbfb95a5"},
+  "atecc508a": {:hex, :atecc508a, "1.4.0", "272eda41001765b11356be43bc25314c73c47e4144a3eba96db6feddf0142e68", [:mix], [{:circuits_i2c, "~> 0.2 or ~> 1.0 or ~> 2.0", [hex: :circuits_i2c, repo: "hexpm", optional: false]}, {:x509, "~> 0.5.1 or ~> 0.6", [hex: :x509, repo: "hexpm", optional: false]}], "hexpm", "3643442e4fa53c8cf85c3db0dab8f683f3e91bf69595cc2ee5b28d1742872f65"},
   "circuits_i2c": {:hex, :circuits_i2c, "2.1.0", "0656ea5d106744c498a8cd778f39c0685ab574e3da7159814cfbfe709001f0e5", [:make, :mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "3751a875a9d728080fdbc5fd352f728d4746a82e17e52f4444c406200349f6ac"},
   "dialyxir": {:hex, :dialyxir, "1.4.5", "ca1571ac18e0f88d4ab245f0b60fa31ff1b12cbae2b11bd25d207f865e8ae78a", [:mix], [{:erlex, ">= 0.2.7", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "b0fb08bb8107c750db5c0b324fa2df5ceaa0f9307690ee3c1f6ba5b9eb5d35c3"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.43", "34b2f401fe473080e39ff2b90feb8ddfeef7639f8ee0bbf71bb41911831d77c5", [:mix], [], "hexpm", "970a3cd19503f5e8e527a190662be2cee5d98eed1ff72ed9b3d1a3d466692de8"},
@@ -11,5 +11,5 @@
   "makeup_erlang": {:hex, :makeup_erlang, "1.0.2", "03e1804074b3aa64d5fad7aa64601ed0fb395337b982d9bcf04029d68d51b6a7", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "af33ff7ef368d5893e4a267933e7744e46ce3cf1f61e2dccf53a111ed3aa3727"},
   "nerves_key_pkcs11": {:hex, :nerves_key_pkcs11, "1.2.0", "73fa6796a515de9d4feaad9bc68b2c63b1e5ba9cb32328fa2b349b896a2d18da", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "d4e515edb8838d0de7776ca920cc0e5b6767de95c15070979492d0315b72de19"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.2", "8efba0122db06df95bfaa78f791344a89352ba04baedd3849593bfce4d0dc1c6", [:mix], [], "hexpm", "4b21398942dda052b403bbe1da991ccd03a053668d147d53fb8c4e0efe09c973"},
-  "x509": {:hex, :x509, "0.8.10", "5d1ec6d5f4db31982f9dc34e6a1eebd631d04599e0b6c1c259f1dadd4495e11f", [:mix], [], "hexpm", "a191221665af28b9bdfff0c986ef55f80e126d8ce751bbdf6cefa846410140c0"},
+  "x509": {:hex, :x509, "0.9.2", "a75aa605348abd905990f3d2dc1b155fcde4e030fa2f90c4a91534405dce0f6e", [:mix], [], "hexpm", "4c5ede75697e565d4b0f5be04c3b71bb1fd3a090ea243af4bd7dae144e48cfc7"},
 }


### PR DESCRIPTION
This configuration locks down the private key and an AES encryption key using the ATECC608 persistent latch and volatile key mechanisms. The device is provisioned with an activation key that needs to be kept for unlocking the device.

This allows implementing secret storage as long as you can physically protect the device and manage power to it using a tamper switch or similar. The authorization is kept in volatile memory that will survive sleep but not losing power.

Also adds livebooks for provisioning and testing volatile keys.