### PR TITLE
Add more detail to ProvisioningInfo

### DIFF
--- a/lib/nerves_key.ex
+++ b/lib/nerves_key.ex
@@ -507,15 +507,19 @@ defmodule NervesKey do
   @doc """
   Return default provisioning info for a NervesKey
 
-  This function is used for pre-programmed NervesKey devices. The
-  serial number is a Base32-encoded version of the ATECC508A/608A's globally unique
-  serial number. No additional care is needed to keep the number unique.
+  This function is particularly useful for pre-programmed NervesKey devices.
+  Theserial number is a Base32-encoded version of the ATECC508A/608A's globally
+  unique serial number. No additional care is needed to keep the number unique.
+
+  It also provides information about the provisioning mode. Helping identify a
+  volatile configuration or custom, unrecognized configurations.
   """
   @spec default_info(ATECC508A.Transport.t()) :: ProvisioningInfo.t()
   def default_info(transport) do
-    {:ok, sn} = Config.device_sn(transport)
-
-    %ProvisioningInfo{manufacturer_sn: Base.encode32(sn, padding: false), board_name: "NervesKey"}
+    case Config.provisioning_info(transport) do
+      {:ok, info} -> info
+      _ -> ProvisioningInfo.default()
+    end
   end
 
   @doc """

--- a/lib/nerves_key/config.ex
+++ b/lib/nerves_key/config.ex
@@ -12,6 +12,7 @@ defmodule NervesKey.Config do
   """
 
   alias ATECC508A.Configuration
+  alias NervesKey.ProvisioningInfo
 
   # See README.md for the SlotConfig and KeyConfig values. These are copied verbatim.
   @key_config <<0x33, 0x00, 0x1C, 0x00, 0x1C, 0x00, 0x1C, 0x00, 0x1C, 0x00, 0x1C, 0x00, 0x1C,
@@ -419,6 +420,38 @@ defmodule NervesKey.Config do
       else
         :ok
       end
+    end
+  end
+
+  @doc """
+  Helper for getting provisioning information.
+  """
+  @spec provisioning_info(ATECC508A.Transport.t()) ::
+          {:error, atom()} | {:ok, ProvisioningInfo.t()}
+  def provisioning_info(transport) do
+    with {:ok, info} <- Configuration.read(transport) do
+      mode =
+        if info.lock_value == 0 do
+          case Configuration.read_all_raw(transport) do
+            {:ok, <<_::20-bytes, 0x87::8, 0x20::8, _::74-bytes, 0x33::8, 0x10::8, _::binary>>} ->
+              :volatile
+
+            {:ok, <<_::20-bytes, 0x87::8, 0x20::8, _::binary>>} ->
+              :regular
+
+            {:ok, _bin} ->
+              :unrecognized
+          end
+        else
+          :unprovisioned
+        end
+
+      {:ok,
+       %ProvisioningInfo{
+         manufacturer_sn: Base.encode32(info.serial_number, padding: false),
+         board_name: "NervesKey",
+         mode: mode
+       }}
     end
   end
 

--- a/lib/nerves_key/provisioning_info.ex
+++ b/lib/nerves_key/provisioning_info.ex
@@ -3,10 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 defmodule NervesKey.ProvisioningInfo do
-  defstruct [:manufacturer_sn, :board_name]
+  defstruct manufacturer_sn: "", board_name: "NervesKey", mode: :unprovisioned
 
   @type t :: %__MODULE__{
           manufacturer_sn: binary(),
-          board_name: binary()
+          board_name: binary(),
+          mode: :unprovisioned | :regular | :volatile | :unrecognized
         }
+
+  def default do
+    %__MODULE__{}
+  end
 end


### PR DESCRIPTION
This allows determining the way a chip is configured.

Primarily useful to differentiate between volatile and regular NervesKey configurations.